### PR TITLE
chore(deps): update dependency babel-eslint to ^8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.13.1"
   },
   "devDependencies": {
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": "^8.0.0",
     "eslint": "^2.1.0",
     "eslint-plugin-filenames": "^1.1.0",
     "standard": "^7.1.2"


### PR DESCRIPTION
This Pull Request updates dependency [babel-eslint](https://github.com/babel/babel-eslint) from `^6.1.2` to `^8.0.0`



<details>
<summary>Release Notes</summary>

### [`v7.0.0`](https://github.com/babel/babel-eslint/releases/v7.0.0)

### v7.0.0
#### FYI `https://github.com/babel/babel-eslint/issues/88`

We're looking for more contributors maintainers, I don't have as much time to work on babel-eslint since babel needs a lot of help as well).
#### Changelog
- Drop node < 4 (#&#8203;358)
- Remove the lodash.assign dependency (#&#8203;393)
- Remove eslint 2 logic (#&#8203;361)
  - Remove logic for accounting for async/await before eslint supported it (#&#8203;350)

ESLint v3.6.0 supports async/await (you don't need always need babel-eslint)

http://eslint.org/blog/2016/09/eslint-v3.6.0-released#support-for-es2017

``` js
{
    "parserOptions": {
        "ecmaVersion": 2017,
        "sourceType": "module"
    }
}
```

---

### [`v7.1.0`](https://github.com/babel/babel-eslint/releases/v7.1.0)

### v7.1.0
#### 🚀 New Feature
- Adding support to lint `dynamicImport` (#&#8203;413) @&#8203;kesne 

Babylon support was added in https://github.com/babel/babylon/releases/tag/v6.12.0

``` js
import(`./section-modules/${link.dataset.entryModule}.js`)
.then(module => {
  module.loadPageInto(main);
})
```

---

### [`v7.1.1`](https://github.com/babel/babel-eslint/releases/v7.1.1)

#### v7.1.1
##### 💅 Polish
- Append the code frame on parse error (#&#8203;418) @&#8203;hzoo

Before

<img width="861" alt="screen shot 2016-10-28 at 5 33 11 pm" src="https://cloud.githubusercontent.com/assets/588473/19823087/d7bb535a-9d34-11e6-8b39-3634b95ab155.png">

After

<img width="863" alt="screen shot 2016-10-28 at 5 32 58 pm" src="https://cloud.githubusercontent.com/assets/588473/19823090/daa5d9fa-9d34-11e6-9707-554355e5cc92.png">

---

### [`v7.2.0`](https://github.com/babel/babel-eslint/releases/v7.2.0)

##### New Feature

* Add option to disable code frame. (#&#8203;446) (Luís Couto)

Main change is just an option to disable the codeframe (added in [v7.1.1](https://github.com/babel/babel-eslint/releases/tag/v7.1.1)) for html output and more (thanks to @&#8203;Couto).

```json
{
  "parser": "babel-eslint",
  "parserOptions": {
    "codeFrame": false
  },
  "extends": "eslint:recommended"
}
```
##### Bug Fix

 * [flow] Process polymorphic type bounds on functions (#&#8203;444) (Alex Rattray)
##### Internal/Docs

 * Use `lodash` instead of `lodash.pickby`. (#&#8203;435) (wtgtybhertgeghgtwtg)
 * Updates ESLint version/remove unnecessary config (Kai Cataldo)
 * Remove broken ESLint tests (Kai Cataldo)
 * Upgrade outdated dependencies (Kai Cataldo)
 * remove deprecated rule examples [skip ci] (Henry Zhu)
 * update readme [skip ci] (Henry Zhu)
 * chore(package): update eslint-config-babel to version 6.0.0 (#&#8203;433) (Henry Zhu)
 * Update to use Node 4 features (#&#8203;425) (Nazim Hajidin)
 * chore(package): update eslint-config-babel to version 4.0.0 (#&#8203;430) (greenkeeper[bot])
 * add badges [skip ci] (Henry Zhu)
 * Revert "use `*`" (#&#8203;426) (Henry Zhu)
 * use `*` (#&#8203;421) (Henry Zhu)
 * chore(package): update eslint-config-babel to version 3.0.0 (#&#8203;423) (greenkeeper[bot])

---

### [`v7.2.2`](https://github.com/babel/babel-eslint/releases/v7.2.2)

##### v7.2.2

- Lots of cleanup by @&#8203;zertosh 
- @&#8203;vitorbal added support for ESLint 4 alpha.

---

 * Fix: use eslint-scope instead of escope if present (#&#8203;461) (Vitor Balocco)
 * Separate finding peer deps from monkeypatching (#&#8203;460) (Andres Suarez)
 * Remove unused .gitmodules (#&#8203;457) (Andres Suarez)
 * Use dedent for unpadding (#&#8203;456) (Andres Suarez)
 * Enable strict mode in all of babylon-to-espree (Andres Suarez)
 * Move ast convert steps to babylon-to-espree (Andres Suarez)
 * Use for-loop for template literal conversion (Andres Suarez)
 * Only iterate over tokens once (Andres Suarez)
 * Inline fixDirectives and use for-loop (Andres Suarez)
 * Consolidate versions of "convertComments" (Andres Suarez)
 * toAst pass "source" in state instead of keeping in scope (Andres Suarez)
 * Add type parameter scope tests (#&#8203;454) (Andres Suarez)

---

### [`v7.2.3`](https://github.com/babel/babel-eslint/releases/v7.2.3)

#### Fix
- `https://github.com/babel/babel-eslint/pull/465`

---

### [`v8.0.0`](https://github.com/babel/babel-eslint/releases/v8.0.0)

#### 8.0.0

No major changes, just updating babel deps to v7

---

### [`v8.0.1`](https://github.com/babel/babel-eslint/releases/v8.0.1)

#### v8.0.1

Handle optionalCatchBinding: `https://github.com/babel/babel-eslint/pull/521`

---

### [`v8.1.0`](https://github.com/babel/babel-eslint/releases/v8.1.0)

Use ESLint's API to customize scope analysis and avoid monkeypatching: `https://github.com/babel/babel-eslint/pull/542`

---

</details>


<details>
<summary>Commits</summary>

#### v7.1.0
-   [`41b9542`](https://github.com/babel/babel-eslint/commit/41b9542ed6dc93a116047f3355bff3d8a86b2034) [import()] Adding support to lint dynamic imports (#&#8203;413)
-   [`931d8a9`](https://github.com/babel/babel-eslint/commit/931d8a91d634b48f3b26f1f506da68435dbe955e) 7.1.0
#### v7.1.1
-   [`971c8d6`](https://github.com/babel/babel-eslint/commit/971c8d6afc396ac4c60b12fcd8669f5a34918f58) chore(package): update eslint to version 3.9.1 (#&#8203;419)
-   [`e7c9a03`](https://github.com/babel/babel-eslint/commit/e7c9a0320a394694092944b825a98acee278dcc3) chore(package): update babylon to version 6.13.0 (#&#8203;420)
-   [`2d587d6`](https://github.com/babel/babel-eslint/commit/2d587d657c7fae661e3730566ab3e6803a2344d1) append code frame on parse error (#&#8203;418)
-   [`baeb99b`](https://github.com/babel/babel-eslint/commit/baeb99bdbe70e3479305d1c3a1f618a6bb178a5e) chore(package): update dependencies (#&#8203;422)
-   [`bc482f4`](https://github.com/babel/babel-eslint/commit/bc482f4479e73f4609d97dc9c7abda848d7ccc63) 7.1.1
#### v7.2.0
-   [`1eddb39`](https://github.com/babel/babel-eslint/commit/1eddb390add2f6ca412b612c133ce4a708c14461) chore(package): update eslint-config-babel to version 3.0.0 (#&#8203;423)
-   [`161b8e7`](https://github.com/babel/babel-eslint/commit/161b8e7a887dbc94c821c73a8aba4d449447371c) use `*` (#&#8203;421)
-   [`a91a9d0`](https://github.com/babel/babel-eslint/commit/a91a9d0fe4b69dd4985bf8e42046057de165c2e5) Revert &quot;use `*`&quot; (#&#8203;426)
-   [`e6af5c5`](https://github.com/babel/babel-eslint/commit/e6af5c501f752b4f3e071ade5e8fd96a471cda41) add badges [skip ci]
-   [`265d219`](https://github.com/babel/babel-eslint/commit/265d2190499176c7cd5a70f4a1f4fb5f8bc823ea) chore(package): update eslint-config-babel to version 4.0.0 (#&#8203;430)
-   [`781dc77`](https://github.com/babel/babel-eslint/commit/781dc77f45d52b022b758380009d0c57e023f831) Update to use Node 4 features (#&#8203;425)
-   [`0e5aca3`](https://github.com/babel/babel-eslint/commit/0e5aca3fa81347c40f1fe638bef70e6d8d01f034) chore(package): update eslint-config-babel to version 6.0.0 (#&#8203;433)
-   [`52b4a13`](https://github.com/babel/babel-eslint/commit/52b4a138a06eefe4a482fd5438937dd54cf272ab) update readme [skip ci]
-   [`bdeb86f`](https://github.com/babel/babel-eslint/commit/bdeb86f0d02af714bffee5b319844fc623414c6d) remove deprecated rule examples [skip ci]
-   [`6b4c4ca`](https://github.com/babel/babel-eslint/commit/6b4c4ca36a9d1930468fb105c1d88fa4d908c315) Upgrade outdated dependencies
-   [`702d6b8`](https://github.com/babel/babel-eslint/commit/702d6b8279549df555451e4fe64173eb4b803327) Remove broken ESLint tests
-   [`b49ab20`](https://github.com/babel/babel-eslint/commit/b49ab204a2091861f9645ce95e019ee88a9b08eb) Updates ESLint version/remove unnecessary config
-   [`ce66e73`](https://github.com/babel/babel-eslint/commit/ce66e73749dc33520013399f8585cfe00e755c09) Merge pull request #&#8203;447 from kaicataldo/clean-up-eslint
-   [`515adef`](https://github.com/babel/babel-eslint/commit/515adefc54bb6097ad2fdc076614606ad0ae4262) Add option to disable code frame. (#&#8203;446)
-   [`a2c3b30`](https://github.com/babel/babel-eslint/commit/a2c3b30e6a86a39e0cb44a95a1990ca54415bd1f) [flow] Process polymorphic type bounds on functions (#&#8203;444)
-   [`4499412`](https://github.com/babel/babel-eslint/commit/44994124941b1e50772ee2661cf5d8c910105308) Use `lodash` instead of `lodash.pickby`. (#&#8203;435)
-   [`4db4db5`](https://github.com/babel/babel-eslint/commit/4db4db54d18d5d2833ed9a02c5e4cde20474e995) 7.2.0
#### v7.2.1
-   [`7972a05`](https://github.com/babel/babel-eslint/commit/7972a052e72f44802d0860c5491abe80158a7e43) Update README.md with codeFrame option (#&#8203;448)
-   [`eb05812`](https://github.com/babel/babel-eslint/commit/eb05812e8d3d7e203fa555f42288ff3e0ed8bd5f) Format non-regression errors for legibility (#&#8203;451)
-   [`f1cee0f`](https://github.com/babel/babel-eslint/commit/f1cee0f23193fb222270d69986313a3bd2453ba6) Remove lodash dependency (#&#8203;450)
-   [`b5fb53b`](https://github.com/babel/babel-eslint/commit/b5fb53b718d15e95252197b5f30787ca807d069a) Fix type param and interface declaration scoping (#&#8203;449)
-   [`5626de1`](https://github.com/babel/babel-eslint/commit/5626de120d866f7c99df78566af2514a1674199c) Remove left over eslint 2 estraverse code (#&#8203;452)
-   [`3cda62e`](https://github.com/babel/babel-eslint/commit/3cda62ee066c741b766526155dcdb98db1a2a2d5) 7.2.1
#### v7.2.2
-   [`21dac73`](https://github.com/babel/babel-eslint/commit/21dac7391470b8eb24a07cd11c527293df3c7a23) Add type parameter scope tests (#&#8203;454)
-   [`2541fc9`](https://github.com/babel/babel-eslint/commit/2541fc93b9bacf179661d8e27e040afe011e2926) toAst pass &quot;source&quot; in state instead of keeping in scope
-   [`5d32ad0`](https://github.com/babel/babel-eslint/commit/5d32ad0d56c8769aeea680cc7a4aafa1df4c2a04) Consolidate versions of &quot;convertComments&quot;
-   [`06c3a31`](https://github.com/babel/babel-eslint/commit/06c3a31b96cb890fe3544931f60f021e5186f62a) Inline fixDirectives and use for-loop
-   [`539af05`](https://github.com/babel/babel-eslint/commit/539af05bae280d15059d783b59d77b8814a48084) Only iterate over tokens once
-   [`d2ce789`](https://github.com/babel/babel-eslint/commit/d2ce7894bc864ed46c0c91eeef60af0a91886d8a) Use for-loop for template literal conversion
-   [`6c5beec`](https://github.com/babel/babel-eslint/commit/6c5beec589cbf343c528f1a78efe42874d7c83d4) Move ast convert steps to babylon-to-espree
-   [`ec14787`](https://github.com/babel/babel-eslint/commit/ec14787172795c81fa2c544d100727d897521ebe) Enable strict mode in all of babylon-to-espree
-   [`cdb92fe`](https://github.com/babel/babel-eslint/commit/cdb92fe60d25980a8e9c66acc8c32d81de01aca1) Merge pull request #&#8203;455 from babel/babylon-to-espree-tidy
-   [`a750684`](https://github.com/babel/babel-eslint/commit/a750684e477ab72d4a62822a965c7c8f909aa37d) Use dedent for unpadding (#&#8203;456)
-   [`1201e12`](https://github.com/babel/babel-eslint/commit/1201e12800bbb4badb55620100bc871193572784) Remove unused .gitmodules (#&#8203;457)
-   [`0f611b8`](https://github.com/babel/babel-eslint/commit/0f611b83311d1b44912fc1dd0fc2cd88a0ae9d0c) Separate finding peer deps from monkeypatching (#&#8203;460)
-   [`8622009`](https://github.com/babel/babel-eslint/commit/862200945ee2860cbd00e770280dda3d56b055eb) Fix: use eslint-scope instead of escope if present (#&#8203;461)
-   [`f59d200`](https://github.com/babel/babel-eslint/commit/f59d2009652e14acf1231a1268a8324cf046514e) 7.2.2
#### v7.2.3
-   [`dfaff04`](https://github.com/babel/babel-eslint/commit/dfaff04bad37823842aec19fe131f75a069b7799) Fix flow type spread handling (#&#8203;465)
-   [`94bb5a1`](https://github.com/babel/babel-eslint/commit/94bb5a1d36c5624fb612de2dd704ffa586d38845) 7.2.3
#### v8.0.0
-   [`42d0c5b`](https://github.com/babel/babel-eslint/commit/42d0c5b20cf65ae4100d06aa8dcaf372723f378d) Remove already fixed workaround (#&#8203;508)
-   [`49493e4`](https://github.com/babel/babel-eslint/commit/49493e496de2072e94229a02605637e51152eeef) update to beta.0
-   [`905887c`](https://github.com/babel/babel-eslint/commit/905887c4fe4e5f4b56e34acb526e80aad83880cb) 8.0.0
#### v8.0.1
-   [`5742b71`](https://github.com/babel/babel-eslint/commit/5742b713746accacfcf4dfae1cb67bcefcc6d43a) Adding optionalCatchBinding to plugins. (#&#8203;521)
#### v8.0.2
-   [`51100c9`](https://github.com/babel/babel-eslint/commit/51100c960ae151989d4eea1ec52d2ef5a2f5a2de) chore(package): update mocha to version 4.0.0 (#&#8203;524)
-   [`c1a7882`](https://github.com/babel/babel-eslint/commit/c1a78824688425f12687e79124fc847d484034eb) Update README.md support (#&#8203;531) [skip ci]
-   [`54ab4ac`](https://github.com/babel/babel-eslint/commit/54ab4ac772364b2742aafb9a2549d81a57bd42a5) 8.0.1
-   [`d3b8519`](https://github.com/babel/babel-eslint/commit/d3b8519d935dbc4e6bf538548c0002afde916603) fix(package): update babylon to version 7.0.0-beta.31 (#&#8203;533)
-   [`295091d`](https://github.com/babel/babel-eslint/commit/295091df9146a725abd69e43c7863aa4741853c3) Allow ^ version for babel dependencies (#&#8203;534)
-   [`fa56d21`](https://github.com/babel/babel-eslint/commit/fa56d21f3e9acd023fc4610ca36666e3a3078bbb) Always use unpad (#&#8203;535)
-   [`2004b91`](https://github.com/babel/babel-eslint/commit/2004b913c7abef8d21cebca7f3ae39a9deaee767) require correct deps
-   [`a0fbd50`](https://github.com/babel/babel-eslint/commit/a0fbd503d89fbaddca0aea0bcd277812df17a97d) 8.0.2
#### v8.0.3
-   [`0609da8`](https://github.com/babel/babel-eslint/commit/0609da87289c05c83823ec768d8986c11002d821) Lock down dependency versions.
-   [`cf5ab03`](https://github.com/babel/babel-eslint/commit/cf5ab038988b622f5c3f951533081418da9b0602) Fix mocha command path.
-   [`1f220c2`](https://github.com/babel/babel-eslint/commit/1f220c28cf32f2a2f4b6e5963247b21f4ad5edfb) 8.0.3
#### v8.1.0
-   [`dbc6546`](https://github.com/babel/babel-eslint/commit/dbc6546e0713a83c3362bb28d2d4604dbbebcf19) Use new scopeManager/visitorKeys APIs (#&#8203;542)
-   [`bba9d00`](https://github.com/babel/babel-eslint/commit/bba9d00dec48e0d0fea4160d7f53433ab605c4d4) Re-add parseNoPatch function (accidentally removed) (#&#8203;557)
-   [`893a5e3`](https://github.com/babel/babel-eslint/commit/893a5e308e237c77b733224aeeaece53df6dd326) 8.1.0
#### v8.1.1
-   [`e4bed5a`](https://github.com/babel/babel-eslint/commit/e4bed5a4d5757b44d145d683a2f5aaa28a4f96ef) Fix: Prevent parseForESLint() behavior from changing after parse() is called (fixes #&#8203;558)(#&#8203;559)
-   [`d84b236`](https://github.com/babel/babel-eslint/commit/d84b236467474940c7794135d7b10866d54374c5) 8.1.1
#### v8.1.2
-   [`bf9092a`](https://github.com/babel/babel-eslint/commit/bf9092ab6c3bccf5c9d4cbc91de59d7edfe3641e) Fix: ignore eval (fixes #&#8203;560) (#&#8203;561)
-   [`5aaf0e1`](https://github.com/babel/babel-eslint/commit/5aaf0e1be5fdfc05fae39015a5bebcc7cf0723b7) Fix: add Literal type to visitorKeys (#&#8203;562)
-   [`36bf8b4`](https://github.com/babel/babel-eslint/commit/36bf8b450d822ab78a1093d5361a34e7052cb375) 8.1.2
#### v8.2.0
-   [`1dedd1b`](https://github.com/babel/babel-eslint/commit/1dedd1bf282ba7df77b95c8163af88ad0dc5e378) update babel packages (#&#8203;565)
-   [`e201fb4`](https://github.com/babel/babel-eslint/commit/e201fb470794ee2153bc6504054e9798add2a19b) Make 2018 the default ecmaVersion for rules relying on parserOptions (#&#8203;556)
-   [`eba5920`](https://github.com/babel/babel-eslint/commit/eba5920e29ce8be62d517510653f1391b6e98b01) Add other parser plugins, update yarn.lock (#&#8203;569)
-   [`ef27670`](https://github.com/babel/babel-eslint/commit/ef276702e73a74d284fcafa71e3da2992c11c5a3) 8.2.0
#### v8.2.1
-   [`d96ce55`](https://github.com/babel/babel-eslint/commit/d96ce555904bc7d12841fa8fb6f18da70ba23947) fix export change (#&#8203;571)
-   [`bf27f60`](https://github.com/babel/babel-eslint/commit/bf27f6021e3a3661589bfa1e314f45876edeb20b) 8.2.1
#### v8.2.2
-   [`236adb8`](https://github.com/babel/babel-eslint/commit/236adb8e49cc20252c092d0e965aacebba1a7a7d) Fix: wrong token type of ! and ~ (fixes #&#8203;576) (#&#8203;577)
-   [`29b12ab`](https://github.com/babel/babel-eslint/commit/29b12abc4427b34e21f872c3e5302984a7022b42) Bump deps (#&#8203;591)
-   [`f958995`](https://github.com/babel/babel-eslint/commit/f958995e712fe8ee4da6f1b8d1d3577906b2ad58) chore(package): update lint-staged to version 6.1.1 (#&#8203;592)
-   [`7928722`](https://github.com/babel/babel-eslint/commit/7928722e4d6dea45576ca9196a8879421a362567) Update dependencies
-   [`51afa9e`](https://github.com/babel/babel-eslint/commit/51afa9e34642b83d4f43f657d44e329662bd9c75) Allow newer versions of babel
-   [`9a6d663`](https://github.com/babel/babel-eslint/commit/9a6d66305e2d81f5674b5f227b0d3f1dcb0a3106) 8.2.2

</details>