### PR TITLE
chore(deps): update dependency eslint to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^8.0.0",
-    "eslint": "^2.1.0",
+    "eslint": "^4.0.0",
     "eslint-plugin-filenames": "^1.1.0",
     "standard": "^11.0.0"
   }


### PR DESCRIPTION
This Pull Request updates dependency [eslint](https://github.com/eslint/eslint) from `^2.1.0` to `^4.0.0`



<details>
<summary>Release Notes</summary>

### [`v3.0.0`](https://github.com/eslint/eslint/releases/v3.0.0)

- 66de9d8 Docs: Update installation instructions on README (#&#8203;6569) (Nicholas C. Zakas)
- dc5b78b Breaking: Add `require-yield` rule to `eslint:recommended` (fixes #&#8203;6550) (#&#8203;6554) (Gyandeep Singh)
- 7988427 Fix: lib/config.js tests pass if personal config exists (fixes #&#8203;6559) (#&#8203;6566) (Kevin Partington)
- 4c05967 Docs: Update rule docs for new format (fixes #&#8203;5417) (#&#8203;6551) (Nicholas C. Zakas)
- 70da5a8 Docs: Correct link to rules page (#fixes 6553) (#&#8203;6561) (alberto)
- e2b2030 Update: Check RegExp strings for `no-regex-spaces` (fixes #&#8203;3586) (#&#8203;6379) (Jackson Ray Hamilton)
- 397e51b Update: Implement outerIIFEBody for indent rule (fixes #&#8203;6259) (#&#8203;6382) (David Shepherd)
- 666da7c Docs: 3.0.0 migration guide (#&#8203;6521) (Nicholas C. Zakas)
- b9bf8fb Docs: Update Governance Policy (fixes #&#8203;6452) (#&#8203;6522) (Nicholas C. Zakas)
- 1290657 Update: `no-unused-vars` ignores read it modifies itself (fixes #&#8203;6348) (#&#8203;6535) (Toru Nagashima)
- d601f6b Fix: Delete cache only when executing on files (fixes #&#8203;6459) (#&#8203;6540) (Kai Cataldo)
- e0d4b19 Breaking: Error thrown/printed if no config found (fixes #&#8203;5987) (#&#8203;6538) (Kevin Partington)
- 18663d4 Fix: false negative of `no-useless-rename` (fixes #&#8203;6502) (#&#8203;6506) (Toru Nagashima)
- 0a7936d Update: Add fixer for prefer-const (fixes #&#8203;6448) (#&#8203;6486) (Nick Heiner)
- c60341f Chore: Update index and `meta` for `"eslint:recommended"` (refs #&#8203;6403) (#&#8203;6539) (Mark Pedrotti)
- 73da28d Better wording for the error reported by the rule "no-else-return" #&#8203;6411 (#&#8203;6413) (Olivier Thomann)
- e06a5b5 Update: Add fixer for arrow-parens (fixes #&#8203;4766) (#&#8203;6501) (madmed88)
- 5f8f3e8 Docs: Remove Box as a sponsor (#&#8203;6529) (Nicholas C. Zakas)
- 7dfe0ad Docs: fix max-lines samples (fixes #&#8203;6516) (#&#8203;6515) (Dmitriy Shekhovtsov)
- fa05119 Breaking: Update eslint:recommended (fixes #&#8203;6403) (#&#8203;6509) (Nicholas C. Zakas)
- e96177b Docs: Add "Proposing a Rule Change" link to CONTRIBUTING.md (#&#8203;6511) (Kevin Partington)
- bea9096 Docs: Update pull request steps (fixes #&#8203;6474) (#&#8203;6510) (Nicholas C. Zakas)
- 7bcf6e0 Docs: Consistent example headings & text pt3 (refs #&#8203;5446) (#&#8203;6492) (Guy Fraser)
- 1a328d9 Docs: Consistent example headings & text pt4 (refs #&#8203;5446) (#&#8203;6493) (Guy Fraser)
- ff5765e Docs: Consistent example headings & text pt2 (refs #&#8203;5446)(#&#8203;6491) (Guy Fraser)
- 01384fa Docs: Fixing typos (refs #&#8203;5446)(#&#8203;6494) (Guy Fraser)
- 4343ae8 Fix: false negative of `object-shorthand` (fixes #&#8203;6429) (#&#8203;6434) (Toru Nagashima)
- b7d8c7d Docs: more accurate yoda-speak (#&#8203;6497) (Tony Lukasavage)
- 3b0ab0d Fix: add warnIgnored flag to CLIEngine.executeOnText (fixes #&#8203;6302) (#&#8203;6305) (Robert Levy)
- c2c6cec Docs: Mark object-shorthand as fixable. (#&#8203;6485) (Nick Heiner)
- 5668236 Fix: Allow objectsInObjects exception when destructuring (fixes #&#8203;6469) (#&#8203;6470) (Adam Renklint)
- 17ac0ae Fix: `strict` rule reports a syntax error for ES2016 (fixes #&#8203;6405) (#&#8203;6464) (Toru Nagashima)
- 4545123 Docs: Rephrase documentation for `no-duplicate-imports` (#&#8203;6463) (Simen Bekkhus)
- 1b133e3 Docs: improve `no-native-reassign` and specifying globals (fixes #&#8203;5358) (#&#8203;6462) (Toru Nagashima)
- b179373 Chore: Remove dead code in excuteOnFiles (fixes #&#8203;6467) (#&#8203;6466) (Andrew Hutchings)
- 18fbc4b Chore: Simplify eslint process exit code (fixes #&#8203;6368) (#&#8203;6371) (alberto)
- 58542e4 Breaking: Drop support for node < 4 (fixes #&#8203;4483) (#&#8203;6401) (alberto)
- f50657e Breaking: use default for complexity in eslint:recommended (fixes #&#8203;6021) (#&#8203;6410) (alberto)
- 3e690fb Fix: Exit init early if guide is chosen w/ no package.json (fixes #&#8203;6476) (#&#8203;6478) (Kai Cataldo)

---

### [`v3.0.1`](https://github.com/eslint/eslint/releases/v3.0.1)

- 27700cf Fix: `no-unused-vars` false positive around callback (fixes #&#8203;6576) (#&#8203;6579) (Toru Nagashima)
- 124d8a3 Docs: Pull request template (#&#8203;6568) (Nicholas C. Zakas)
- e9a2ed9 Docs: Fix rules\id-length exceptions typos (fixes #&#8203;6397) (#&#8203;6593) (GramParallelo)
- a2cfa1b Fix: Make outerIIFEBody work correctly (fixes #&#8203;6585) (#&#8203;6596) (Nicholas C. Zakas)
- 9c451a2 Docs: Use string severity in example (#&#8203;6601) (Kenneth Williams)
- 8308c0b Chore: remove path-is-absolute in favor of the built-in (fixes #&#8203;6598) (#&#8203;6600) (shinnn)
- 7a63717 Docs: Add missing pull request step (fixes #&#8203;6595) (#&#8203;6597) (Nicholas C. Zakas)
- de3ed84 Fix: make `no-unused-vars` ignore for-in (fixes #&#8203;2342) (#&#8203;6126) (Oleg Gaidarenko)
- 6ef2cbe Fix: strip Unicode BOM of config files (fixes #&#8203;6556) (#&#8203;6580) (Toru Nagashima)
- ee7fcfa Docs: Correct type of `outerIIFEBody` in `indent` (fixes #&#8203;6581) (#&#8203;6584) (alberto)
- 25fc7b7 Fix: false negative of `max-len` (fixes #&#8203;6564) (#&#8203;6565) (not-an-aardvark)
- f6b8452 Docs: Distinguish examples in rules under Stylistic Issues part 6 (#&#8203;6567) (Kenneth Williams)

---

### [`v3.1.0`](https://github.com/eslint/eslint/releases/v3.1.0)

- e8f8c6c Fix: incorrect exitCode when eslint is called with --stdin (fixes #&#8203;6677) (#&#8203;6682) (Steven Humphrey)
- 38639bf Update: make `no-var` fixable (fixes #&#8203;6639) (#&#8203;6644) (Toru Nagashima)
- dfc20e9 Fix: `no-unused-vars` false positive in loop (fixes #&#8203;6646) (#&#8203;6649) (Toru Nagashima)
- 2ba75d5 Update: relax outerIIFEBody definition (fixes #&#8203;6613) (#&#8203;6653) (Stephen E. Baker)
- 421e4bf Chore: combine multiple RegEx replaces with one (fixes #&#8203;6669) (#&#8203;6661) (Sakthipriyan Vairamani)
- 089ee2c Docs: fix typos,wrong path,backticks (#&#8203;6663) (molee1905)
- ef827d2 Docs: Add another pre-commit hook to integrations (#&#8203;6666) (David Alan Hjelle)
- a343b3c Docs: Fix option typo in no-underscore-dangle (Fixes #&#8203;6674) (#&#8203;6675) (Luke Page)
- 5985eb2 Chore: add internal rule that validates meta property (fixes #&#8203;6383) (#&#8203;6608) (Vitor Balocco)
- 4adb15f Update: Add `balanced` option to `spaced-comment` (fixes #&#8203;4133) (#&#8203;6575) (Annie Zhang)
- 1b13c25 Docs: fix incorrect example being mark as correct (#&#8203;6660) (David Björklund)
- a8b4e40 Fix: Install required eslint plugin for "standard" guide (fixes #&#8203;6656) (#&#8203;6657) (Feross Aboukhadijeh)
- 720686b New: `endLine` and `endColumn` of the lint result. (refs #&#8203;3307) (#&#8203;6640) (Toru Nagashima)
- 54faa46 Docs: Small tweaks to CLI documentation (fixes #&#8203;6627) (#&#8203;6642) (Kevin Partington)
- e108850 Docs: Added examples and structure to `padded-blocks` (fixes #&#8203;6628) (#&#8203;6643) (alberto)
- 350e1c0 Docs: Typo (#&#8203;6650) (Peter Rood)
- b837c92 Docs: Correct a term in max-len.md (fixes #&#8203;6637) (#&#8203;6641) (Vse Mozhet Byt)
- baeb313 Fix: Warning behavior for executeOnText (fixes #&#8203;6611) (#&#8203;6632) (Nicholas C. Zakas)
- e6004be Chore: Enable preferType in valid-jsdoc (refs #&#8203;5188) (#&#8203;6634) (Nicholas C. Zakas)
- ca323cf Fix: Use default assertion messages (fixes #&#8203;6532) (#&#8203;6615) (Dmitrii Abramov)
- 2bdf22c Fix: Do not throw exception if baseConfig is provided (fixes #&#8203;6605) (#&#8203;6625) (Kevin Partington)
- e42cacb Upgrade: mock-fs to 3.10, fixes for Node 6.3 (fixes #&#8203;6621) (#&#8203;6624) (Tim Schaub)
- 8a263ae New: multiline-ternary rule (fixes #&#8203;6066) (#&#8203;6590) (Kai Cataldo)
- e951303 Update: Adding new `key-spacing` option (fixes #&#8203;5613) (#&#8203;5907) (Kyle Mendes)
- 10c3e91 Docs: Remove reference from 3.0.0 migration guide (refs #&#8203;6605) (#&#8203;6618) (Kevin Partington)
- 5010694 Docs: Removed non-existing resource (#&#8203;6609) (Moritz Kröger)
- 6d40d85 Docs: Note that PR requires ACCEPTED issue (refs #&#8203;6568) (#&#8203;6604) (Patrick McElhaney)

---

### [`v3.1.1`](https://github.com/eslint/eslint/releases/v3.1.1)

- 565e584 Fix: `eslint:all` causes regression in 3.1.0 (fixes #&#8203;6687) (#&#8203;6696) (alberto)
- cb90359 Fix: Allow named recursive functions (fixes #&#8203;6616) (#&#8203;6667) (alberto)
- 3f206dd Fix: `balanced` false positive in `spaced-comment` (fixes #&#8203;6689) (#&#8203;6692) (Grant Snodgrass)
- 57f1676 Docs: Add missing brackets from code examples (#&#8203;6700) (Plusb Preco)
- 124f066 Chore: Remove fixable key from multiline-ternary metadata (fixes #&#8203;6683) (#&#8203;6688) (Kai Cataldo)
- 9f96086 Fix: Escape control characters in XML. (fixes #&#8203;6673) (#&#8203;6672) (George Chung)

---

### [`v3.2.0`](https://github.com/eslint/eslint/releases/v3.2.0)

- 2438ee2 Upgrade: Update markdownlint dependency to 0.2.0 (fixes #&#8203;6781) (#&#8203;6782) (David Anson)
- 4fc0018 Chore: dogfooding `no-var` rule and remove `var`s (refs #&#8203;6407) (#&#8203;6757) (Toru Nagashima)
- b22eb5c New: `no-tabs` rule (fixes #&#8203;6079) (#&#8203;6772) (Gyandeep Singh)
- ddea63a Chore: Updated no-control-regex tests to cover all cases (fixes #&#8203;6438) (#&#8203;6752) (Efe Gürkan YALAMAN)
- 1025772 Docs: Add plugin example to disabling with comments guide (fixes #&#8203;6742) (#&#8203;6747) (Brandon Mills)
- 628aae4 Docs: fix inconsistent spacing inside block comment (#&#8203;6768) (Brian Jacobel)
- 2983c32 Docs: Add options to func-names config comments (#&#8203;6748) (Brandon Mills)
- 2f94443 Docs: fix wrong path (#&#8203;6763) (molee1905)
- 6f3faa4 Revert "Build: Remove support for Node v5 (fixes #&#8203;6743)" (#&#8203;6758) (Nicholas C. Zakas)
- 99dfd1c Docs: fix grammar issue in rule-changes page (#&#8203;6761) (Vitor Balocco)
- e825458 Fix: Rule no-unused-vars had missing period (fixes #&#8203;6738) (#&#8203;6739) (Brian Mock)
- 71ae64c Docs: Clarify cache file deletion (fixes #&#8203;4943) (#&#8203;6712) (Nicholas C. Zakas)
- 26c85dd Update: merge warnings of consecutive unreachable nodes (fixes #&#8203;6583) (#&#8203;6729) (Toru Nagashima)
- 106e40b Fix: Correct grammar in object-curly-newline reports (fixes #&#8203;6725) (#&#8203;6728) (Vitor Balocco)
- e00754c Chore: Dogfooding ES6 rules (refs #&#8203;6407) (#&#8203;6735) (alberto)
- 181b26a Build: Remove support for Node v5 (fixes #&#8203;6743) (#&#8203;6744) (alberto)
- 5320a6c Update: `no-use-before-define` false negative on for-in/of (fixes #&#8203;6699) (#&#8203;6719) (Toru Nagashima)
- a2090cb Fix: space-infix-ops doesn't fail for  type annotations(fixes #&#8203;5211) (#&#8203;6723) (Nicholas C. Zakas)
- 9c36ecf Docs: Add @&#8203;vitorbal and @&#8203;platinumazure to development team (Ilya Volodin)
- e09d1b8 Docs: describe all RuleTester options (fixes #&#8203;4810, fixes #&#8203;6709) (#&#8203;6711) (Nicholas C. Zakas)
- a157f47 Chore: Update CLIEngine option desc (fixes #&#8203;5179) (#&#8203;6713) (Nicholas C. Zakas)
- a0727f9 Chore: fix `.gitignore` for vscode (refs #&#8203;6383) (#&#8203;6720) (Toru Nagashima)
- 75d2d43 Docs: Clarify Closure type hint expectation (fixes #&#8203;5231) (#&#8203;6714) (Nicholas C. Zakas)
- 95ea25a Update: Check indentation of multi-line chained properties (refs #&#8203;1801) (#&#8203;5940) (Rich Trott)
- e7b1e1c Docs: Edit issue/PR waiting period docs (fixes #&#8203;6009) (#&#8203;6715) (Nicholas C. Zakas)
- 053aa0c Update: Added 'allowSuper' option to `no-underscore-dangle` (fixes #&#8203;6355) (#&#8203;6662) (peteward44)
- 8929045 Build: Automatically generate rule index (refs #&#8203;2860) (#&#8203;6658) (Ilya Volodin)
- f916ae5 Docs: Fix multiline-ternary typos (#&#8203;6704) (Cédric Malard)
- c64b0c2 Chore: First ES6 refactoring (refs #&#8203;6407) (#&#8203;6570) (Nicholas C. Zakas)

---

### [`v3.2.1`](https://github.com/eslint/eslint/releases/v3.2.1)

- 584577a Build: Pin file-entry-cache to avoid licence issue (refs #&#8203;6816) (#&#8203;6818) (alberto)
- 38d0d23 Docs: clarify minor releases and suggest using `~ to version (#&#8203;6804) (Henry Zhu)
- 4ca809e Fix: Normalizes messages so all end with a period (fixes #&#8203;6762) (#&#8203;6807) (Patrick McElhaney)
- c7488ac Fix: Make MemberExpression option opt-in (fixes #&#8203;6797) (#&#8203;6798) (Rich Trott)
- 715e8fa Docs: Update issue closing policy (fixes #&#8203;6765) (#&#8203;6808) (Nicholas C. Zakas)
- 288f7bf Build: Fix site generation (fixes #&#8203;6791) (#&#8203;6793) (Nicholas C. Zakas)
- 261a9f3 Docs: Update JSCS status in README (#&#8203;6802) (alberto)
- 5ae0887 Docs: Update no-void.md (#&#8203;6799) (Daniel Hritzkiv)

---

### [`v3.2.2`](https://github.com/eslint/eslint/releases/v3.2.2)

- 510ce4b Upgrade: file-entry-cache@&#8203;^1.3.1 (fixes #&#8203;6816, refs #&#8203;6780) (#&#8203;6819) (alberto)
- 46b14cd Fix: ignore MemberExpression in VariableDeclarators (fixes #&#8203;6795) (#&#8203;6815) (Nicholas C. Zakas)

---

### [`v3.3.0`](https://github.com/eslint/eslint/releases/v3.3.0)

- 683ac56 Build: Add CI release scripts (fixes #&#8203;6884) (#&#8203;6885) (Nicholas C. Zakas)
- ebf8441 Update: `prefer-rest-params` relax for member accesses (fixes #&#8203;5990) (#&#8203;6871) (Toru Nagashima)
- df01c4f Update: Add regex support for exceptions (fixes #&#8203;5187) (#&#8203;6883) (Annie Zhang)
- 055742c Fix: `no-dupe-keys` type errors (fixes #&#8203;6886) (#&#8203;6889) (Toru Nagashima)
- e456fd3 New: `sort-keys` rule (fixes #&#8203;6076) (#&#8203;6800) (Toru Nagashima)
- 3e879fc Update: Rule "eqeqeq" to have more specific null handling (fixes #&#8203;6543) (#&#8203;6849) (Simon Sturmer)
- e8cb7f9 Chore: use eslint-plugin-node (refs #&#8203;6407) (#&#8203;6862) (Toru Nagashima)
- e37bbd8 Docs: Remove duplicate statement (#&#8203;6878) (Richard Käll)
- 11395ca Fix: `no-dupe-keys` false negative (fixes #&#8203;6801) (#&#8203;6863) (Toru Nagashima)
- 1ecd2a3 Update: improve error message in `no-control-regex` (#&#8203;6839) (Jordan Harband)
- d610d6c Update: make `max-lines` report the actual number of lines (fixes #&#8203;6766) (#&#8203;6764) (Jarek Rencz)
- b256c50 Chore: Fix glob for core js files for lint (fixes #&#8203;6870) (#&#8203;6872) (Gyandeep Singh)
- f8ab8f1 New: func-call-spacing rule (fixes #&#8203;6080) (#&#8203;6749) (Brandon Mills)
- be68f0b New: no-template-curly-in-string rule (fixes #&#8203;6186) (#&#8203;6767) (Jeroen Engels)
- 80789ab Chore: don't throw if rule is in old format (fixes #&#8203;6848) (#&#8203;6850) (Vitor Balocco)
- d47c505 Fix: `newline-after-var` false positive (fixes #&#8203;6834) (#&#8203;6847) (Toru Nagashima)
- bf0afcb Update: validate void operator in no-constant-condition (fixes #&#8203;5726) (#&#8203;6837) (Vitor Balocco)
- 5ef839e New: Add consistent and ..-as-needed to object-shorthand (fixes #&#8203;5438) (#&#8203;5439) (Martijn de Haan)
- 7e1bf01 Fix: update peerDependencies of airbnb option for `--init` (fixes #&#8203;6843) (#&#8203;6846) (Vitor Balocco)
- 8581f4f Fix: `no-invalid-this` false positive (fixes #&#8203;6824) (#&#8203;6827) (Toru Nagashima)
- 90f78f4 Update: add `props` option to `no-self-assign` rule (fixes #&#8203;6718) (#&#8203;6721) (Toru Nagashima)
- 30d71d6 Update: 'requireForBlockBody' modifier for 'arrow-parens' (fixes #&#8203;6557) (#&#8203;6558) (Nicolas Froidure)
- cdded07 Chore: use native `Object.assign` (refs #&#8203;6407) (#&#8203;6832) (Gyandeep Singh)
- 579ec49 Chore: Add link to rule change guidelines in "needs info" template (fixes #&#8203;6829) (#&#8203;6831) (Kevin Partington)
- 117e7aa Docs: Remove incorrect "constructor" statement from `no-new-symbol` docs (#&#8203;6830) (Jarek Rencz)
- aef18b4 New: `no-unsafe-negation` rule (fixes #&#8203;2716) (#&#8203;6789) (Toru Nagashima)
- d94e945 Docs: Update Getting Started w/ Readme installation instructions (#&#8203;6823) (Kai Cataldo)
- dfbc112 Upgrade: proxyquire to 1.7.10 (fixes #&#8203;6821) (#&#8203;6822) (alberto)
- 4c5e911 Chore: enable `prefer-const` and apply it to our codebase (refs #&#8203;6407) (#&#8203;6805) (Toru Nagashima)
- e524d16 Update: camelcase rule fix for import declarations (fixes #&#8203;6755) (#&#8203;6784) (Lorenzo Zottar)
- 8f3509d Update: make `eslint:all` excluding deprecated rules (fixes #&#8203;6734) (#&#8203;6756) (Toru Nagashima)
- 2b17459 New: `no-global-assign` rule (fixes #&#8203;6586) (#&#8203;6746) (alberto)

---

### [`v3.3.1`](https://github.com/eslint/eslint/releases/v3.3.1)

- a2f06be Build: optimize rule page title for small browser tabs (fixes #&#8203;6888) (#&#8203;6904) (Vitor Balocco)
- 02a00d6 Docs: clarify rule details for no-template-curly-in-string (#&#8203;6900) (not-an-aardvark)
- b9b3446 Fix: sort-keys ignores destructuring patterns (fixes #&#8203;6896) (#&#8203;6899) (Kai Cataldo)
- 3fe3a4f Docs: Update options in `object-shorthand` (#&#8203;6898) (Grant Snodgrass)
- cd09c96 Chore: Use object-shorthand batch 2 (refs #&#8203;6407) (#&#8203;6897) (Kai Cataldo)
- 2841008 Chore: Use object-shorthand batch 1 (refs #&#8203;6407) (#&#8203;6893) (Kai Cataldo)

---

### [`v3.4.0`](https://github.com/eslint/eslint/releases/v3.4.0)

- c210510 Update: add fixer for no-extra-parens (fixes #&#8203;6944) (#&#8203;6950) (not-an-aardvark)
- ca3d448 Fix: `prefer-const` false negative about `eslintUsed` (fixes #&#8203;5837) (#&#8203;6971) (Toru Nagashima)
- 1153955 Docs: Draft of JSCS migration guide (refs #&#8203;5859) (#&#8203;6942) (Nicholas C. Zakas)
- 3e522be Fix: false negative of `indent` with `else if` statements (fixes #&#8203;6956) (#&#8203;6965) (not-an-aardvark)
- 2dfb290 Docs: Distinguish examples in rules under Stylistic Issues part 7 (#&#8203;6760) (Kenneth Williams)
- 3c710c9 Fix: rename "AirBnB" => "Airbnb" init choice (fixes #&#8203;6969) (Harrison Shoff)
- 7660b39 Fix: `object-curly-spacing` for type annotations (fixes #&#8203;6940) (#&#8203;6945) (Toru Nagashima)
- 21ab784 New: do not remove non visited files from cache. (fixes #&#8203;6780) (#&#8203;6921) (Roy Riojas)
- 3a1763c Fix: enable `@scope/plugin/ruleId`-style specifier (refs #&#8203;6362) (#&#8203;6939) (Toru Nagashima)
- d6fd064 Update: Add never option to multiline-ternary (fixes #&#8203;6751) (#&#8203;6905) (Kai Cataldo)
- 0d268f1 New: `symbol-description` rule (fixes #&#8203;6778) (#&#8203;6825) (Jarek Rencz)
- a063d4e Fix: no-cond-assign within a function expression (fixes #&#8203;6908) (#&#8203;6909) (Patrick McElhaney)
- 16db93a Build: Tag docs, publish release notes (fixes #&#8203;6892) (#&#8203;6934) (Nicholas C. Zakas)
- 0cf1d55 Chore: Fix object-shorthand errors (fixes #&#8203;6958) (#&#8203;6959) (Kai Cataldo)
- 8851ddd Fix: Improve pref of globbing by inheriting glob.GlobSync (fixes #&#8203;6710) (#&#8203;6783) (Kael Zhang)
- cf2242c Update: `requireStringLiterals` option for `valid-typeof` (fixes #&#8203;6698) (#&#8203;6923) (not-an-aardvark)
- 8561389 Fix: `no-trailing-spaces` wrong fixing (fixes #&#8203;6933) (#&#8203;6937) (Toru Nagashima)
- 6a92be5 Docs: Update semantic versioning policy (#&#8203;6935) (alberto)
- a5189a6 New: `class-methods-use-this` rule (fixes #&#8203;5139) (#&#8203;6881) (Gyandeep Singh)
- 1563808 Update: add support for ecmaVersion 20xx (fixes #&#8203;6750) (#&#8203;6907) (Kai Cataldo)
- d8b770c Docs: Change rule descriptions for consistent casing (#&#8203;6915) (Brandon Mills)
- c676322 Chore: Use object-shorthand batch 3 (refs #&#8203;6407) (#&#8203;6914) (Kai Cataldo)

---

### [`v3.5.0`](https://github.com/eslint/eslint/releases/v3.5.0)

- 08fa538 Update: fix false negative of `arrow-spacing` (fixes #&#8203;7079) (#&#8203;7080) (Toru Nagashima)
- cec65e3 Update: add fixer for no-floating-decimal (fixes #&#8203;7070) (#&#8203;7081) (not-an-aardvark)
- 2a3f699 Fix: Column number for no-multiple-empty-lines (fixes #&#8203;7086) (#&#8203;7088) (Ian VanSchooten)
- 6947299 Docs: Add info about closing accepted issues to docs (fixes #&#8203;6979) (#&#8203;7089) (Kai Cataldo)
- d30157a Docs: Add link to awesome-eslint in integrations page (#&#8203;7090) (Vitor Balocco)
- 457be1b Docs: Update so issues are not required (fixes #&#8203;7015) (#&#8203;7072) (Nicholas C. Zakas)
- d9513b7 Fix: Allow linting of .hidden files/folders (fixes #&#8203;4828) (#&#8203;6844) (Ian VanSchooten)
- 6d97c18 New: `max-len`: `ignoreStrings`+`ignoreTemplateLiterals` (fixes #&#8203;5805) (#&#8203;7049) (Jordan Harband)
- 538d258 Update: make no-implicit-coercion support autofixing. (fixes #&#8203;7056) (#&#8203;7061) (Eli White)
- 883316d Update: add fixer for prefer-arrow-callback (fixes #&#8203;7002) (#&#8203;7004) (not-an-aardvark)
- 7502eed Update: auto-fix for `comma-style` (fixes #&#8203;6941) (#&#8203;6957) (Gyandeep Singh)
- 645dda5 Update: add fixer for dot-notation (fixes #&#8203;7014) (#&#8203;7054) (not-an-aardvark)
- 2657846 Fix: `no-console` ignores user-defined console (fixes #&#8203;7010) (#&#8203;7058) (Toru Nagashima)
- 656bb6e Update: add fixer for newline-before-return (fixes #&#8203;5958) (#&#8203;7050) (Vitor Balocco)
- 1f995c3 Fix: no-implicit-coercion string concat false positive (fixes #&#8203;7057) (#&#8203;7060) (Kai Cataldo)
- 6718749 Docs: Clarify that `es6` env also sets `ecmaVersion` to 6 (#&#8203;7067) (Jérémie Astori)
- e118728 Update: add fixer for wrap-regex (fixes #&#8203;7013) (#&#8203;7048) (not-an-aardvark)
- f4fcd1e Update: add more `indent` options for functions (fixes #&#8203;6052) (#&#8203;7043) (not-an-aardvark)
- 657eee5 Update: add fixer for new-parens (fixes #&#8203;6994) (#&#8203;7047) (not-an-aardvark)
- ff19aa9 Update: improve `max-statements-per-line` message (fixes #&#8203;6287) (#&#8203;7044) (Jordan Harband)
- 3960617 New: `prefer-numeric-literals` rule (fixes #&#8203;6068) (#&#8203;7029) (Annie Zhang)
- fa760f9 Chore: no-regex-spaces uses internal rule message format (fixes #&#8203;7052) (#&#8203;7053) (Kevin Partington)
- 22c7e09 Update: no-magic-numbers false negative on reassigned vars (fixes #&#8203;4616) (#&#8203;7028) (not-an-aardvark)
- be29599 Update: Throw error if whitespace found in plugin name (fixes #&#8203;6854) (#&#8203;6960) (Jesse Ostrander)
- 4063a79 Fix: Rule message placeholders can be inside braces (fixes #&#8203;6988) (#&#8203;7041) (Kevin Partington)
- 52e8d9c Docs: Clean up sort-vars (#&#8203;7045) (Matthew Dunsdon)
- 4126f12 Chore: Rule messages use internal rule message format (fixes #&#8203;6977) (#&#8203;6989) (Kevin Partington)
- 46cb690 New: `no-restricted-properties` rule (fixes #&#8203;3218) (#&#8203;7017) (Eli White)
- 00b3042 Update: Pass file path to parse function (fixes #&#8203;5344) (#&#8203;7024) (Annie Zhang)
- 3f13325 Docs: Add kaicataldo and JamesHenry to our teams (#&#8203;7039) (alberto)
- 8e77f16 Update: `new-parens` false negative (fixes #&#8203;6997) (#&#8203;6999) (Toru Nagashima)
- 326f457 Docs: Add missing 'to' in no-restricted-modules (#&#8203;7022) (Oskar Risberg)
- 8277357 New: `line-comment-position` rule (fixes #&#8203;6077) (#&#8203;6953) (alberto)
- c1f0d76 New: `lines-around-directive` rule (fixes #&#8203;6069) (#&#8203;6998) (Kai Cataldo)
- 61f1de0 Docs: Fix typo in no-debugger (#&#8203;7019) (Denis Ciccale)
- 256c4a2 Fix: Allow separate mode option for multiline and align (fixes #&#8203;6691) (#&#8203;6991) (Annie Zhang)
- a989a7c Docs: Declaring dependency on eslint in shared config (fixes #&#8203;6617) (#&#8203;6985) (alberto)
- 6869c60 Docs: Fix minor typo in no-extra-parens doc (#&#8203;6992) (Jérémie Astori)
- 28f1619 Docs: Update the example of SwitchCase (#&#8203;6981) (fish)

---

### [`v3.6.0`](https://github.com/eslint/eslint/releases/v3.6.0)

- 1b05d9c Update: add fixer for `strict` (fixes #&#8203;6668) (#&#8203;7198) (Teddy Katz)
- 0a36138 Docs: Update ecmaVersion instructions (#&#8203;7195) (Nicholas C. Zakas)
- aaa3779 Update: Allow `space-unary-ops` to handle await expressions (#&#8203;7174) (Teddy Katz)
- 91bf477 Update: add fixer for `prefer-template` (fixes #&#8203;6978) (#&#8203;7165) (Teddy Katz)
- 745343f Update: `no-extra-parens` supports async/await (refs #&#8203;7101) (#&#8203;7178) (Toru Nagashima)
- 8e1fee1 Fix: Handle number literals correctly in `no-whitespace-before-property` (#&#8203;7185) (Teddy Katz)
- 462a3f7 Update: `keyword-spacing` supports async/await (refs #&#8203;7101) (#&#8203;7179) (Toru Nagashima)
- 709a734 Update: Allow template string in `valid-typeof` comparison (fixes #&#8203;7166) (#&#8203;7168) (Teddy Katz)
- f71937a Fix: Don't report async/generator callbacks in `array-callback-return` (#&#8203;7172) (Teddy Katz)
- 461b015 Fix: Handle async functions correctly in `prefer-arrow-callback` fixer (#&#8203;7173) (Teddy Katz)
- 7ea3e4b Fix: Handle await expressions correctly in `no-unused-expressions` (#&#8203;7175) (Teddy Katz)
- 16bb802 Update: Ensure `arrow-parens` handles async arrow functions correctly (#&#8203;7176) (Teddy Katz)
- 2d10657 Chore: add tests for `generator-star-spacing` and async (refs #&#8203;7101) (#&#8203;7182) (Toru Nagashima)
- c118d21 Update: Let `no-restricted-properties` check destructuring (fixes #&#8203;7147) (#&#8203;7151) (Teddy Katz)
- 9e0b068 Fix: valid-jsdoc does not throw on FieldType without value (fixes #&#8203;7184) (#&#8203;7187) (Kai Cataldo)
- 4b5d9b7 Docs: Update process for evaluating proposals (fixes #&#8203;7156) (#&#8203;7183) (Kai Cataldo)
- 95c777a Update: Make `no-restricted-properties` more flexible (fixes #&#8203;7137) (#&#8203;7139) (Teddy Katz)
- 0fdf23c Update: fix `quotes` rule's false negative (fixes #&#8203;7084) (#&#8203;7141) (Toru Nagashima)
- f2a789d Update: fix `no-unused-vars` false negative (fixes #&#8203;7124) (#&#8203;7143) (Toru Nagashima)
- 6148d85 Fix: Report columns for `eol-last` correctly (fixes #&#8203;7136) (#&#8203;7149) (kdex)
- e016384 Update: add fixer for quote-props (fixes #&#8203;6996) (#&#8203;7095) (Teddy Katz)
- 35f7be9 Upgrade: espree to 3.2.0, remove tests with SyntaxErrors (fixes #&#8203;7169) (#&#8203;7170) (Teddy Katz)
- 28ddcf8 Fix: `max-len`: `ignoreTemplateLiterals`: handle 3+ lines (fixes #&#8203;7125) (#&#8203;7138) (Jordan Harband)
- 660e091 Docs: Update rule descriptions (fixes #&#8203;5912) (#&#8203;7152) (Kenneth Williams)
- 8b3fc32 Update: Make `indent` report lines with mixed spaces/tabs (fixes #&#8203;4274) (#&#8203;7076) (Teddy Katz)
- b39ac2c Update: add fixer for `no-regex-spaces` (#&#8203;7113) (Teddy Katz)
- cc80467 Docs: Update PR templates for formatting (#&#8203;7128) (Nicholas C. Zakas)
- 76acbb5 Fix: include LogicalExpression in indent length calc  (fixes #&#8203;6731) (#&#8203;7087) (Alec)
- a876673 Update: no-implicit-coercion checks TemplateLiterals (fixes #&#8203;7062) (#&#8203;7121) (Kai Cataldo)
- 8db4f0c Chore: Enable `typeof` check for `no-undef` rule in eslint-config-eslint (#&#8203;7103) (Teddy Katz)
- 7e8316f Docs: Update release process (#&#8203;7127) (Nicholas C. Zakas)
- 22edd8a Update: `class-methods-use-this`: `exceptions` option (fixes #&#8203;7085) (#&#8203;7120) (Jordan Harband)
- afd132a Fix: line-comment-position "above" string option now works (fixes #&#8203;7100) (#&#8203;7102) (Kevin Partington)
- 1738b2e Chore: fix name of internal-no-invalid-meta test file (#&#8203;7142) (Vitor Balocco)
- ac0bb62 Docs: Fixes examples for allowTemplateLiterals (fixes #&#8203;7115) (#&#8203;7135) (Zoe Ingram)
- bcfa3e5 Update: Add `always`/`never` option to `eol-last` (fixes #&#8203;6938) (#&#8203;6952) (kdex)
- 0ca26d9 Docs: Distinguish examples for space-before-blocks (#&#8203;7132) (Timo Tijhof)
- 9a2aefb Chore: Don't require an issue reference in check-commit npm script (#&#8203;7104) (Teddy Katz)
- c85fd84 Fix: max-statements-per-line rule to force minimum to be 1 (fixes #&#8203;7051) (#&#8203;7092) (Scott Stern)
- e462e47 Docs: updates category of no-restricted-properties (fixes #&#8203;7112) (#&#8203;7118) (Alec)
- 6ae660b Fix: Don't report comparisons of two typeof expressions (fixes #&#8203;7078) (#&#8203;7082) (Teddy Katz)
- 710f205 Docs: Fix typos in Issues section of Maintainer's Guide (#&#8203;7114) (Kai Cataldo)
- 546a3ca Docs: Clarify that linter does not process configuration (fixes #&#8203;7108) (#&#8203;7110) (Kevin Partington)
- 0d50943 Docs: Elaborate on `guard-for-in` best practice (fixes #&#8203;7071) (#&#8203;7094) (Dallon Feldner)
- 58e6d76 Docs: Fix examples for no-restricted-properties (#&#8203;7099) (not-an-aardvark)
- 6cfe519 Docs: Corrected typo in line-comment-position rule doc (#&#8203;7097) (Alex Mercier)
- f02e52a Docs: Add fixable note to no-implicit-coercion docs (#&#8203;7096) (Brandon Mills)

---

### [`v3.6.1`](https://github.com/eslint/eslint/releases/v3.6.1)

- b467436 Upgrade: Upgrade Espree to 3.3.1 (#&#8203;7253) (Ilya Volodin)
- 299a563 Build: Do not strip .md extension from absolute URLs (#&#8203;7222) (Kai Cataldo)
- 27042d2 Chore: removed unused code related to scopeMap (#&#8203;7218) (Yang Su)
- d154204 Chore: Lint bin/eslint.js (#&#8203;7243) (Kevin Partington)
- 87625fa Docs: Improve eol-last examples in docs (#&#8203;7227) (Chainarong Tangsurakit)
- de8eaa4 Docs: `class-methods-use-this`: fix option name (#&#8203;7224) (Jordan Harband)
- 2355f8d Docs: Add Brunch plugin to integrations (#&#8203;7225) (Aleksey Shvayka)
- a5817ae Docs: Default option from `operator-linebreak` is `after`and not always (#&#8203;7228) (Konstantin Pschera)

---

### [`v3.7.0`](https://github.com/eslint/eslint/releases/v3.7.0)

- 2fee8ad Fix: object-shorthand's consistent-as-needed option (issue #&#8203;7214) (#&#8203;7215) (Naomi Jacobs)
- c05a19c Update: add fixer for `prefer-numeric-literals` (#&#8203;7205) (Teddy Katz)
- 2f171f3 Update: add fixer for `no-undef-init` (#&#8203;7210) (Teddy Katz)
- 876d747 Docs: Steps for adding new committers/TSCers (#&#8203;7221) (Nicholas C. Zakas)
- dffb4fa Fix: `no-unused-vars` false positive (fixes #&#8203;7250) (#&#8203;7258) (Toru Nagashima)
- 4448cec Docs: Adding missing ES8 reference to configuring (#&#8203;7271) (Kevin Partington)
- 332d213 Update: Ensure `indent` handles nested functions correctly (fixes #&#8203;7249) (#&#8203;7265) (Teddy Katz)
- c36d842 Update: add fixer for `no-useless-computed-key` (#&#8203;7207) (Teddy Katz)
- 18376cf Update: add fixer for `lines-around-directive` (#&#8203;7217) (Teddy Katz)
- f8e8fab Update: add fixer for `wrap-iife` (#&#8203;7196) (Teddy Katz)
- 558b444 Docs: Add @&#8203;not-an-aardvark to development team (#&#8203;7279) (Ilya Volodin)
- cd1dc57 Update: Add a fixer for `dot-location` (#&#8203;7186) (Teddy Katz)
- 89787b2 Update: for `yoda`, add a fixer (#&#8203;7199) (Teddy Katz)
- 742ae67 Fix: avoid indent and no-mixed-spaces-and-tabs conflicts (fixes #&#8203;7248) (#&#8203;7266) (Teddy Katz)
- 85b8714 Fix: Use error templates even when reading from stdin (fixes #&#8203;7213) (#&#8203;7223) (Teddy Katz)
- 66adac1 Docs: correction in prefer-reflect docs (fixes #&#8203;7069) (#&#8203;7150) (Scott Stern)
- e3f95de Update: Fix `no-extra-parens` false negative (fixes #&#8203;7229) (#&#8203;7231) (Teddy Katz)
- 2909c19 Docs: Fix typo in object-shorthand docs (#&#8203;7267) (Brian Donovan)
- 7bb800d Chore: add internal rule to enforce meta.docs conventions (fixes #&#8203;6954) (#&#8203;7155) (Vitor Balocco)
- 722c68c Docs: add code fences to the issue template (#&#8203;7254) (Teddy Katz)

---

### [`v3.7.1`](https://github.com/eslint/eslint/releases/v3.7.1)

- 3dcae13 Fix: Use the correct location for `comma-dangle` errors (fixes #&#8203;7291) (#&#8203;7292) (Teddy Katz)
- cb7ba6d Fix: no-implicit-coercion should not fix ~. (fixes #&#8203;7272) (#&#8203;7289) (Eli White)
- ce590e2 Chore: Add additional tests for bin/eslint.js (#&#8203;7290) (Teddy Katz)
- 8ec82ee Docs: change links of templates to raw data (#&#8203;7288) (Toru Nagashima)

---

### [`v3.8.0`](https://github.com/eslint/eslint/releases/v3.8.0)

- ee60acf Chore: add integration tests for autofixing (fixes #&#8203;5909) (#&#8203;7349) (Teddy Katz)
- c8796e9 Update: `comma-dangle` supports trailing function commas (refs #&#8203;7101) (#&#8203;7181) (Toru Nagashima)
- c4abaf0 Update: `space-before-function-paren` supports async/await (refs #&#8203;7101) (#&#8203;7180) (Toru Nagashima)
- d0d3b28 Fix: id-length rule incorrectly firing on member access (fixes #&#8203;6475) (#&#8203;7365) (Burak Yiğit Kaya)
- 2729d94 Fix: Don't report setter params in class bodies as unused (fixes #&#8203;7351) (#&#8203;7352) (Teddy Katz)
- 0b85004 Chore: Enable prefer-template (fixes #&#8203;6407) (#&#8203;7357) (Kai Cataldo)
- ca1947b Chore: Update pull request template (refs eslint/tsc-meetings#&#8203;20) (#&#8203;7359) (Brandon Mills)
- d840afe Docs: remove broken link from no-loop-func doc (#&#8203;7342) (Michael McDermott)
- 5266793 Update: no-useless-escape checks template literals (fixes #&#8203;7331) (#&#8203;7332) (Kai Cataldo)
- b08fb91 Update: add source property to LintResult object (fixes #&#8203;7098) (#&#8203;7304) (Vitor Balocco)
- 0db4164 Chore: run prefer-template autofixer on test files (refs #&#8203;6407) (#&#8203;7354) (Kai Cataldo)
- c1470b5 Update: Make the `prefer-template` fixer unescape quotes (fixes #&#8203;7330) (#&#8203;7334) (Teddy Katz)
- 5d08c33 Fix: Handle parentheses correctly in `yoda` fixer (fixes #&#8203;7326) (#&#8203;7327) (Teddy Katz)
- cd72bba New: `func-name-matching` rule (fixes #&#8203;6065) (#&#8203;7063) (Annie Zhang)
- 55b5146 Fix: `RuleTester` didn't support `mocha --watch` (#&#8203;7287) (Toru Nagashima)
- f8387c1 Update: add fixer for `prefer-spread` (#&#8203;7283) (Teddy Katz)
- 52da71e Fix: Don't require commas after rest properties (fixes #&#8203;7297) (#&#8203;7298) (Teddy Katz)
- 3b11d3f Chore: refactor `no-multiple-empty-lines` (#&#8203;7314) (Teddy Katz)
- 16d495d Docs: Updating CLI overview with latest changes (#&#8203;7335) (Kevin Partington)
- 52dfce5 Update: add fixer for `one-var-declaration-per-line` (#&#8203;7295) (Teddy Katz)
- 0e994ae Update: Improve the error messages for `no-unused-vars` (fixes #&#8203;7282) (#&#8203;7315) (Teddy Katz)
- 93214aa Chore: Convert non-lib/test files to template literals (refs #&#8203;6407) (#&#8203;7329) (Kai Cataldo)
- 72f394d Update: Fix false negative of `no-multiple-empty-lines` (fixes #&#8203;7312) (#&#8203;7313) (Teddy Katz)
- 756bc5a Update: Use characters instead of code units for `max-len` (#&#8203;7299) (Teddy Katz)
- c9a7ec5 Fix: Improving optionator configuration for --print-config (#&#8203;7206) (Kevin Partington)
- 51bfade Fix: avoid `object-shorthand` crash with spread properties (fixes #&#8203;7305) (#&#8203;7306) (Teddy Katz)
- a12d1a9 Update: add fixer for `no-lonely-if` (#&#8203;7202) (Teddy Katz)
- 1418384 Fix: Don't require semicolons before `++`/`--` (#&#8203;7252) (Adrian Heine né Lang)
- 2ffe516 Update: add fixer for `curly` (#&#8203;7105) (Teddy Katz)
- ac3504d Update: add functionPrototypeMethods to wrap-iife (fixes #&#8203;7212) (#&#8203;7284) (Eli White)
- 5e16fb4 Update: add fixer for `no-extra-bind` (#&#8203;7236) (Teddy Katz)

---

### [`v3.8.1`](https://github.com/eslint/eslint/releases/v3.8.1)

- 681c78a Fix: `comma-dangle` was confused by type annotations (fixes #&#8203;7370) (#&#8203;7372) (Toru Nagashima)
- 7525042 Fix: Allow useless escapes in tagged template literals (fixes #&#8203;7383) (#&#8203;7384) (Teddy Katz)
- 9106964 Docs: Fix broken link for stylish formatter (#&#8203;7386) (Vitor Balocco)
- 49d3c1b Docs: Document the deprecated meta property (#&#8203;7367) (Randy Coulman)
- 19d2996 Docs: Relax permission for merging PRs (refs eslint/tsc-meetings#&#8203;20) (#&#8203;7360) (Brandon Mills)

---

### [`v3.9.0`](https://github.com/eslint/eslint/releases/v3.9.0)

- d933516 New: `no-useless-return` rule (fixes #&#8203;7309) (#&#8203;7441) (Toru Nagashima)
- 5e7af30 Update: Add `CallExpression` option for `indent` (fixes #&#8203;5946) (#&#8203;7189) (Teddy Katz)
- b200086 Fix: Support type annotations in array-bracket-spacing (#&#8203;7445) (Jimmy Jia)
- 5ed8b9b Update: Deprecate prefer-reflect (fixes #&#8203;7226) (#&#8203;7464) (Kai Cataldo)
- 92ad43b Chore: Update deprecated rules in conf/eslint.json (#&#8203;7467) (Kai Cataldo)
- e46666b New: Codeframe formatter (fixes #&#8203;5860) (#&#8203;7437) (Vitor Balocco)
- fe0d903 Upgrade: Shelljs to ^0.7.5 (fixes #&#8203;7316) (#&#8203;7465) (Gyandeep Singh)
- 1d5146f Update: fix wrong indentation about `catch`,`finally` (#&#8203;7371) (Toru Nagashima)
- 77e3a34 Chore: Pin mock-fs dev dependency (#&#8203;7466) (Gyandeep Singh)
- c675d7d Update: Fix `no-useless-escape` false negative in regexes (fixes #&#8203;7424) (#&#8203;7425) (Teddy Katz)
- ee3bcea Update: add fixer for `newline-after-var` (fixes #&#8203;5959) (#&#8203;7375) (Teddy Katz)
- 6e9ff08 Fix: indent.js to support multiline array statements. (#&#8203;7237) (Scott Stern)
- f8153ad Build: Ensure absolute links in docs retain .md extensions (fixes #&#8203;7419) (#&#8203;7438) (Teddy Katz)
- 16367a8 Fix: Return statement spacing. Fix for indent rule. (fixes #&#8203;7164) (#&#8203;7197) (Imad Elyafi)
- 3813988 Update: fix false negative of `no-extra-parens` (fixes #&#8203;7122) (#&#8203;7432) (Toru Nagashima)
- 23062e2 Docs: Fix typo in no-unexpected-multiline (fixes #&#8203;7442) (#&#8203;7447) (Denis Sikuler)
- d257428 Update: `func-name-matching`: add “nameMatches” option (fixes #&#8203;7391) (#&#8203;7428) (Jordan Harband)
- c710584 Fix: support for MemberExpression with function body. (#&#8203;7400) (Scott Stern)
- 2c8ed2d Build: ensure that all files are linted on bash (fixes #&#8203;7426) (#&#8203;7427) (Teddy Katz)
- 18ff70f Chore: Enable `no-useless-escape` (#&#8203;7403) (Vitor Balocco)
- 8dfd802 Fix: avoid `camelcase` false positive with NewExpressions (fixes #&#8203;7363) (#&#8203;7409) (Teddy Katz)
- e8159b4 Docs: Fix typo and explain static func calls for class-methods-use-this (#&#8203;7421) (Scott O'Hara)
- 85d7e24 Docs: add additional examples for MemberExpressions in Indent rule. (#&#8203;7408) (Scott Stern)
- 2aa1107 Docs: Include note on fatal: true in the node.js api section (#&#8203;7376) (Simen Bekkhus)
- e064a25 Update: add fixer for `arrow-body-style` (#&#8203;7240) (Teddy Katz)
- e0fe727 Update: add fixer for `brace-style` (fixes #&#8203;7074) (#&#8203;7347) (Teddy Katz)
- cbbe420 New: Support enhanced parsers (fixes #&#8203;6974) (#&#8203;6975) (Nicholas C. Zakas)
- 644d25b Update: Add an ignoreRegExpLiterals option to max-len (fixes #&#8203;3229) (#&#8203;7346) (Wilfred Hughes)
- 6875576 Docs: Remove broken links to jslinterrors.com (fixes #&#8203;7368) (#&#8203;7369) (Dannii Willis)

---

### [`v3.9.1`](https://github.com/eslint/eslint/releases/v3.9.1)

- 2012258 Fix: incorrect `indent` check for array property access (fixes #&#8203;7484) (#&#8203;7485) (Teddy Katz)
- 8a71d4a Fix: `no-useless-return` false positive on conditionals (fixes #&#8203;7477) (#&#8203;7482) (Teddy Katz)
- 56a662b Fix: allow escaped backreferences in `no-useless-escape` (fixes #&#8203;7472) (#&#8203;7474) (Teddy Katz)
- fffdf13 Build: Fix prefer-reflect rule to not crash site gen build (#&#8203;7471) (Ilya Volodin)
- 8ba68a3 Docs: Update broken link (#&#8203;7490) (Devinsuit)
- 65231d8 Docs: add the "fixable" icon for `no-useless-return` (#&#8203;7480) (Teddy Katz)

---

### [`v3.10.0`](https://github.com/eslint/eslint/releases/v3.10.0)

- 7ee039b Update: Add comma-style options for calls, fns, imports (fixes #&#8203;7470) (Max Englander)
- 670e060 Chore: make the `object-shorthand` tests more readable (#&#8203;7580) (Teddy Katz)
- c3f4809 Update: Allow `func-names` to recognize inferred ES6 names (fixes #&#8203;7235) (#&#8203;7244) (Logan Smyth)
- b8d6e48 Fix: syntax errors created by `object-shorthand` autofix (fixes #&#8203;7574) (#&#8203;7575) (Teddy Katz)
- 1b3b65c Chore: ensure that files in tests/conf are linted (#&#8203;7579) (Teddy Katz)
- 2bd1dd7 Update: avoid creating extra whitespace in `arrow-body-style` fixer (#&#8203;7504) (Teddy Katz)
- 66fe9ff New: `no-return-await` rule. (fixes #&#8203;7537) (#&#8203;7547) (Jordan Harband)
- 759525e Chore: Use process.exitCode instead of process.exit() in bin/eslint.js (#&#8203;7569) (Teddy Katz)
- 0d60db7 Fix: Curly rule doesn't account for leading comment (fixes #&#8203;7538) (#&#8203;7539) (Will Chen)
- 5003b1c Update: fix in/instanceof handling with `space-infix-ops` (fixes #&#8203;7525) (#&#8203;7552) (Teddy Katz)
- 3e6131e Docs: explain config option merging (#&#8203;7499) (Danny Andrews)
- 1766524 Update: "Error type should be" assertion in rule-tester (fixes 6106) (#&#8203;7550) (Frans Jaspers)
- 44eb274 Docs: Missing semicolon report was missing a comma (#&#8203;7553) (James)
- 6dbda15 Docs: Document the optional defaults argument for RuleTester (#&#8203;7548) (Teddy Katz)
- e117b80 Docs: typo fix (#&#8203;7546) (oprogramador)
- 25e5613 Chore: Remove incorrect test from indent.js. (#&#8203;7531) (Scott Stern)
- c0f4937 Fix: `arrow-parens` supports type annotations (fixes #&#8203;7406) (#&#8203;7436) (Toru Nagashima)
- a838b8e Docs: `func-name-matching`: update with “always”/“never” option (#&#8203;7536) (Jordan Harband)
- 3c379ff Update: `no-restricted-{imports,modules}`: add “patterns” (fixes #&#8203;6963) (#&#8203;7433) (Jordan Harband)
- f5764ee Docs: Update example of results returned from `executeOnFiles` (#&#8203;7362) (Simen Bekkhus)
- 4613ba0 Fix: Add support for escape char in JSX. (#&#8203;7461) (Scott Stern)
- ea0970d Fix: `curly` false positive with no-semicolon style (#&#8203;7509) (Teddy Katz)
- af1fde1 Update: fix `brace-style` false negative on multiline node (fixes #&#8203;7493) (#&#8203;7496) (Teddy Katz)
- 3798aea Update: max-statements to report function name (refs #&#8203;7260) (#&#8203;7399) (Nicholas C. Zakas)
- 0c215fa Update: Add `ArrowFunctionExpression` support to `require-jsdoc` rule (#&#8203;7518) (Gyandeep Singh)
- 578c373 Build: handle deprecated rules with no 'replacedBy' (refs #&#8203;7471) (#&#8203;7494) (Vitor Balocco)
- a7f3976 Docs: Specify min ESLint version for new rule format (#&#8203;7501) (cowchimp)
- 8a3e717 Update: Fix `lines-around-directive` semicolon handling (fixes #&#8203;7450) (#&#8203;7483) (Teddy Katz)
- e58cead Update: add a fixer for certain statically-verifiable `eqeqeq` cases (#&#8203;7389) (Teddy Katz)
- 0dea0ac Chore: Add Node 7 to travis ci build (#&#8203;7506) (Gyandeep Singh)
- 36338f0 Update: add fixer for `no-extra-boolean-cast` (#&#8203;7387) (Teddy Katz)
- 183def6 Chore: enable `prefer-arrow-callback` on ESLint codebase (fixes #&#8203;6407) (#&#8203;7503) (Teddy Katz)
- 4f1fa67 Docs: Update copyright (#&#8203;7497) (Nicholas C. Zakas)

---

### [`v3.10.1`](https://github.com/eslint/eslint/releases/v3.10.1)

- 8a0e92a Fix: handle try/catch correctly in `no-return-await` (fixes #&#8203;7581) (#&#8203;7582) (Teddy Katz)
- c4dd015 Fix: no-useless-return stack overflow on unreachable loops (fixes #&#8203;7583) (#&#8203;7584) (Teddy Katz)

---

### [`v3.10.2`](https://github.com/eslint/eslint/releases/v3.10.2)

- 0643bfe Fix: correctly handle commented code in `indent` autofixer (fixes #&#8203;7604) (#&#8203;7606) (Teddy Katz)
- bd0514c Fix: syntax error after `key-spacing` autofix with comment (fixes #&#8203;7603) (#&#8203;7607) (Teddy Katz)
- f56c1ef Fix: `indent` crash on parenthesized global return values (fixes #&#8203;7573) (#&#8203;7596) (Teddy Katz)
- 100c6e1 Docs: Fix example for curly "multi-or-nest" option (#&#8203;7597) (Will Chen)
- 6abb534 Docs: Update code of conduct link (#&#8203;7599) (Nicholas C. Zakas)
- 8302cdb Docs: Update no-tabs to match existing standards & improve readbility (#&#8203;7590) (Matt Stow)

---

### [`v3.11.0`](https://github.com/eslint/eslint/releases/v3.11.0)

- ad56694 New: capitalized-comments rule (fixes #&#8203;6055) (#&#8203;7415) (Kevin Partington)
- 7185567 Update: add fixer for `operator-assignment` (#&#8203;7517) (Teddy Katz)
- faf5f56 Update: fix false negative of `quotes` with \n in template (fixes #&#8203;7646) (#&#8203;7647) (Teddy Katz)
- 474e444 Update: add fixer for `sort-imports` (#&#8203;7535) (Teddy Katz)
- f9b70b3 Docs: Enable example highlighting in rules examples (ref #&#8203;6444) (#&#8203;7644) (Alex Guerrero)
- d50f6c1 Fix: incorrect location for `no-useless-escape` errors (fixes #&#8203;7643) (#&#8203;7645) (Teddy Katz)
- 54a993c Docs: Fix a typo in the require-yield.md (#&#8203;7652) (Vse Mozhet Byt)
- eadd808 Chore: Fix prefer-arrow-callback lint errors (#&#8203;7651) (Kevin Partington)
- 89bd8de New: `require-await` rule (fixes #&#8203;6820) (#&#8203;7435) (Toru Nagashima)
- b7432bd Chore: Ensure JS files are checked out with LF (#&#8203;7624) (Kevin Partington)
- 32a3547 Docs: Add absent quotes in rules documentation (#&#8203;7625) (Denis Sikuler)
- 5c9a4ad Fix: Prevent `quotes` from fixing templates to directives (fixes #&#8203;7610) (#&#8203;7617) (Teddy Katz)
- d90ca46 Upgrade: Update markdownlint dependency to 0.3.1 (fixes #&#8203;7589) (#&#8203;7592) (David Anson)
- 07124d1 Docs: add missing quote mark (+=" → "+=") (#&#8203;7613) (Sean Juarez)
- 8998043 Docs: fix wording in docs for no-extra-parens config (Michael Ficarra)

---

### [`v3.11.1`](https://github.com/eslint/eslint/releases/v3.11.1)

- be739d0 Fix: capitalized-comments fatal error fixed (fixes #&#8203;7663) (#&#8203;7664) (Rich Trott)
- cc4cedc Docs: Fix a typo in array-bracket-spacing documentation (#&#8203;7667) (Alex Guerrero)
- f8adadc Docs: fix a typo in capitalized-comments documentation (#&#8203;7666) (Teddy Katz)

---

### [`v3.12.0`](https://github.com/eslint/eslint/releases/v3.12.0)

- e569225 Update: fix false positive/negative of yoda rule (fixes #&#8203;7676) (#&#8203;7695) (Toru Nagashima)
- e95a230 Fix: indent "first" option false positive on nested arrays (fixes #&#8203;7727) (#&#8203;7728) (Teddy Katz)
- 81f9e7d Fix: Allow duplicated let declarations in `prefer-const` (fixes #&#8203;7712) (#&#8203;7717) (Teddy Katz)
- 1d0d61d New: Add no-await-in-loop rule (#&#8203;7563) (Nat Mote)
- 2cdfb4e New: Additional APIs (fixes #&#8203;6256) (#&#8203;7669) (Ilya Volodin)
- 4278c42 Update: make no-obj-calls report errors for Reflect (fixes #&#8203;7700) (#&#8203;7710) (Tomas Echeverri Valencia)
- 4742d82 Docs: clarify the default behavior of `operator-linebreak` (fixes #&#8203;7459) (#&#8203;7726) (Teddy Katz)
- a8489e2 Chore: Avoid parserOptions boilerplate in tests for ES6 rules (#&#8203;7724) (Teddy Katz)
- b921d1f Update: add `indent` options for array and object literals (fixes #&#8203;7473) (#&#8203;7681) (Teddy Katz)
- 7079c89 Update: Add airbnb-base to init styleguides (fixes #&#8203;6986) (#&#8203;7699) (alberto)
- 63bb3f8 Docs: improve the documentation for the autofix API (#&#8203;7716) (Teddy Katz)
- f8786fb Update: add fixer for `capitalized-comments` (#&#8203;7701) (Teddy Katz)
- abfd24f Fix: don't validate schemas for disabled rules (fixes #&#8203;7690) (#&#8203;7692) (Teddy Katz)
- 2ac07d8 Upgrade: Update globals dependency to 9.14.0 (#&#8203;7683) (Aleksandr Oleynikov)
- 90a5d29 Docs: Remove incorrect info about issue requirements from PR guide (#&#8203;7691) (Teddy Katz)
- f80c278 Docs: Add sails-hook-lint to integrations list (#&#8203;7679) (Anthony M)
- e96da3f Docs: link first instance of `package.json` (#&#8203;7684) (Kent C. Dodds)
- bf20e20 Build: include links to rule pages in release blogpost (#&#8203;7671) (Teddy Katz)
- b30116c Docs: Fix code-blocks in spaced-comment docs (#&#8203;7524) (Michał Gołębiowski)
- 0a2a7fd Fix: Allow \u2028 and \u2029 as string escapes in no-useless-escape (#&#8203;7672) (Teddy Katz)
- 76c33a9 Docs: Change Sails.js integration to active npm package (#&#8203;7675) (Anthony M)

---

### [`v3.12.1`](https://github.com/eslint/eslint/releases/v3.12.1)

- 0ad4d33 Fix: `indent` regression with function calls (fixes #&#8203;7732, fixes #&#8203;7733) (#&#8203;7734) (Teddy Katz)
- ab246dd Docs: Rules restricting globals/properties/syntax are linked together (#&#8203;7743) (Kevin Partington)
- df2f115 Docs: Add eslint-config-mdcs to JSCS Migration Guide (#&#8203;7737) (Joshua Koo)
- 4b77333 Build: avoid creating broken rule links in the changelog (#&#8203;7731) (Teddy Katz)

---

### [`v3.12.2`](https://github.com/eslint/eslint/releases/v3.12.2)

- dec3ec6 Fix: indent bug with AssignmentExpressions (fixes #&#8203;7747) (#&#8203;7750) (Teddy Katz)
- 5344751 Build: Don't create blogpost links from rule names within other words (#&#8203;7754) (Teddy Katz)
- 639b798 Docs: Use `Object.prototype` in examples (#&#8203;7755) (Alex Reardon)

---

### [`v3.13.0`](https://github.com/eslint/eslint/releases/v3.13.0)

- cd4c025 Update: add fixer for no-extra-label (#&#8203;7840) (Teddy Katz)
- aa75c92 Fix: Ensure prefer-const fixes destructuring assignments (fixes #&#8203;7852) (#&#8203;7859) (Teddy Katz)
- 4008022 Chore: Refactor to use ES6 Classes (Part 3)(refs #&#8203;7849) (#&#8203;7865) (Gyandeep Singh)
- c9ba40a Update: add fixer for `no-unneeded-ternary` (#&#8203;7540) (Teddy Katz)
- dd56d87 Update: add object-shorthand option for arrow functions (fixes #&#8203;7564) (#&#8203;7746) (Teddy Katz)
- fbafdc0 Docs: `padded-blocks` `never` case (fixes #&#8203;7868) (#&#8203;7878) (alberto)
- ca1f841 Fix: no-useless-return stack overflow on loops after throw (fixes #&#8203;7855) (#&#8203;7856) (Teddy Katz)
- d80d994 Update: add fixer for object-property-newline (fixes #&#8203;7740) (#&#8203;7808) (Teddy Katz)
- bf3ea3a Fix: capitalized-comments: Ignore consec. comments if first is invalid (#&#8203;7835) (Kevin Partington)
- 616611a Chore: Refactor to use ES6 Classes (Part 2)(refs #&#8203;7849) (#&#8203;7847) (Gyandeep Singh)
- 856084b Chore: Refactor to use ES6 Classes (Part 1)(refs #&#8203;7849) (#&#8203;7846) (Gyandeep Singh)
- bf45893 Docs: Clarify that we only support Stage 4 proposals (#&#8203;7845) (Kevin Partington)
- 0fc24f7 Fix: adapt new-paren rule so it handles TypeScript (fixes #&#8203;7817) (#&#8203;7820) (Philipp A)
- df0b06b Fix: no-multiple-empty-lines perf issue on large files (fixes #&#8203;7803) (#&#8203;7843) (Teddy Katz)
- 18fa521 Chore: use ast-utils helper functions in no-multiple-empty-lines (#&#8203;7842) (Teddy Katz)
- 7122205 Docs: Array destructuring example for no-unused-vars (fixes #&#8203;7838) (#&#8203;7839) (Remco Haszing)
- e21b36b Chore: add integration tests for cache files (refs #&#8203;7748) (#&#8203;7794) (Teddy Katz)
- 2322733 Fix: Throw error if ruletester is missing required test scenarios (#&#8203;7388) (Teddy Katz)
- 1beecec Update: add fixer for `operator-linebreak` (#&#8203;7702) (Teddy Katz)
- c5c3b21 Fix: no-implied-eval false positive on 'setTimeoutFoo' (fixes #&#8203;7821) (#&#8203;7836) (Teddy Katz)
- 00dd96c Chore: enable array-bracket-spacing on ESLint codebase (#&#8203;7830) (Teddy Katz)
- ebcae1f Update: no-return-await with with complex `return` argument (fixes #&#8203;7594) (#&#8203;7595) (Dalton Santos)
- fd4cd3b Fix: Disable no-var autofixer in some incorrect cases in loops (#&#8203;7811) (Alan Pierce)
- 1f25834 Docs: update outdated info in Architecture page (#&#8203;7816) (Teddy Katz)
- f20b9e9 Fix: Relax no-useless-escape's handling of ']' in regexes (fixes #&#8203;7789) (#&#8203;7793) (Teddy Katz)
- 3004c1e Fix: consistent-return shouldn't report class constructors (fixes #&#8203;7790) (#&#8203;7797) (Teddy Katz)
- b938f1f Docs: Add an example for the spread operator to prefer-spread.md (#&#8203;7802) (#&#8203;7804) (butlermd)
- b8ce2dc Docs: Remove .html extensions from links in developer-guide (#&#8203;7805) (Kevin Partington)
- aafebb2 Docs: Wrap placeholder sample in {% raw %} (#&#8203;7798) (Daniel Lo Nigro)
- bb6b73b Chore: replace unnecessary function callbacks with arrow functions (#&#8203;7795) (Teddy Katz)
- 428fbdf Fix: func-call-spacing "never" doesn't fix w/ line breaks (fixes #&#8203;7787) (#&#8203;7788) (Kevin Partington)
- 6e61070 Fix: `semi` false positive before regex/template literals (fixes #&#8203;7782) (#&#8203;7783) (Teddy Katz)
- ff0c050 Fix: remove internal property from config generation (fixes #&#8203;7758) (#&#8203;7761) (alberto)
- 27424cb New: `prefer-destructuring` rule (fixes #&#8203;6053) (#&#8203;7741) (Alex LaFroscia)
- bb648ce Docs: fix unclear example for no-useless-escape (#&#8203;7781) (Teddy Katz)
- 8c3a962 Fix: syntax errors from object-shorthand autofix (fixes #&#8203;7744) (#&#8203;7745) (Teddy Katz)
- 8b296a2 Docs: fix in semi.md: correct instead of incorrect (#&#8203;7779) (German Prostakov)
- 3493241 Upgrade: strip-json-comments ~v2.0.1 (Janus Troelsen)
- 75b7ba4 Chore: enable object-curly-spacing on ESLint codebase (refs #&#8203;7725) (#&#8203;7770) (Teddy Katz)
- 7d1dc7e Update: Make default-case comment case-insensitive (fixes #&#8203;7673) (#&#8203;7742) (Robert Rossmann)
- f1bf5ec Chore: convert remaining old-style context.report() calls to the new API (#&#8203;7763) (Teddy Katz)

---

### [`v3.13.1`](https://github.com/eslint/eslint/releases/v3.13.1)

- 3fc4e3f Fix: prefer-destructuring reporting compound assignments (fixes #&#8203;7881) (#&#8203;7882) (Teddy Katz)
- f90462e Fix: no-extra-label autofix should not remove labels used elsewhere (#&#8203;7885) (Teddy Katz)

---

### [`v3.14.0`](https://github.com/eslint/eslint/releases/v3.14.0)

- 506324a Fix: `no-var` does not fix if causes ReferenceError (fixes #&#8203;7950) (#&#8203;7953) (Toru Nagashima)
- 05e7432 New: no-chained-assignments rule (fixes #&#8203;6424) (#&#8203;7904) (Stewart Rand)
- 243e47d Update: Add fixer for no-else-return (fixes #&#8203;7863) (#&#8203;7864) (Xander Dumaine)
- f091d95 New: `prefer-promise-reject-errors` rule (fixes #&#8203;7685) (#&#8203;7689) (Teddy Katz)
- ca01e00 Fix: recognize all line terminators in func-call-spacing (fixes #&#8203;7923) (#&#8203;7924) (Francesco Trotta)
- a664e8a Update: add ignoreJSX option to no-extra-parens (Fixes #&#8203;7444) (#&#8203;7926) (Robert Rossmann)
- 8ac3518 Fix: no-useless-computed-key false positive with `__proto__` (#&#8203;7934) (Teddy Katz)
- c835e19 Docs: remove reference to deleted rule (#&#8203;7942) (Alejandro Oviedo)
- 3c1e63b Docs: Improve examples for no-case-declarations (fixes #&#8203;6716) (#&#8203;7920) (Kevin Rangel)
- 7e04b33 Fix: Ignore inline plugin rule config in autoconfig (fixes #&#8203;7860) (#&#8203;7919) (Ian VanSchooten)
- 6448ba0 Fix: add parentheses in no-extra-boolean-cast autofixer (fixes #&#8203;7912) (#&#8203;7914) (Szymon Przybylski)
- b3f2094 Fix: brace-style crash with lone block statements (fixes #&#8203;7908) (#&#8203;7909) (Teddy Katz)
- 5eb2e88 Docs: Correct typos in configuring.md (#&#8203;7916) (Gabriel Delépine)
- bd5e219 Update: ensure brace-style validates class bodies (fixes #&#8203;7608) (#&#8203;7871) (Teddy Katz)
- 427543a Fix: catastrophic backtracking in astUtils linebreak regex (fixes #&#8203;7893) (#&#8203;7898) (Teddy Katz)
- 995554c Fix: Correct typos in no-alert.md and lib/ast-utils.js (#&#8203;7905) (Stewart Rand)
- d6150e3 Chore: Enable comma-dangle on ESLint codebase (fixes #&#8203;7725) (#&#8203;7906) (Teddy Katz)
- 075ec25 Chore: update to use ES6 classes (refs #&#8203;7849) (#&#8203;7891) (Claire Dranginis)
- 55f0cb6 Update: refactor brace-style and fix inconsistencies (fixes #&#8203;7869) (#&#8203;7870) (Teddy Katz)

---

### [`v3.14.1`](https://github.com/eslint/eslint/releases/v3.14.1)

- 791f32b Fix: brace-style false positive for keyword method names (fixes #&#8203;7974) (#&#8203;7980) (Teddy Katz)
- d7a0add Docs: Add ESLint tutorial embed to getting started (#&#8203;7971) (Jamis Charles)
- 72d41f0 Fix: no-var autofix syntax error in single-line statements (fixes #&#8203;7961) (#&#8203;7962) (Teddy Katz)
- b9e5b68 Fix: indent rule crash on sparse array with object (fixes #&#8203;7959) (#&#8203;7960) (Gyandeep Singh)
- a7bd66a Chore: Adding assign/redeclare tests to no-undefined (refs #&#8203;7964) (#&#8203;7965) (Kevin Partington)
- 8bcbf5d Docs: typo in prefer-promise-reject-errors (#&#8203;7958) (Patrick McElhaney)

---

### [`v3.15.0`](https://github.com/eslint/eslint/releases/v3.15.0)

- f2a3580 Fix: `no-extra-parens` incorrect precedence (fixes #&#8203;7978) (#&#8203;7999) (alberto)
- d6b6ba1 Fix: no-var should fix ForStatement.init (#&#8203;7993) (Toru Nagashima)
- 99d386d Upgrade: Espree v3.4.0 (#&#8203;8019) (Kai Cataldo)
- 42390fd Docs: update README.md for team (#&#8203;8016) (Toru Nagashima)
- d7ffd88 Chore: enable template-tag-spacing on ESLint codebase (#&#8203;8005) (Teddy Katz)
- f2be7e3 Docs: Fix typo in object-curly-newline.md (#&#8203;8002) (Danny Andrews)
- df2351a Docs: Fix misleading section in brace-style documentation (#&#8203;7996) (Teddy Katz)
- 5ae6e00 Chore: avoid unnecessary feature detection for Symbol (#&#8203;7992) (Teddy Katz)
- 5d57c57 Chore: fix no-else-return lint error (refs #&#8203;7986) (#&#8203;7994) (Vitor Balocco)
- 62fb054 Chore: enable no-else-return on ESLint codebase (#&#8203;7986) (Teddy Katz)
- c59a0ba Update: add ignoreRestSiblings option to no-unused-vars (#&#8203;7968) (Zack Argyle)
- 5cdfa99 Chore: enable no-unneeded-ternary on ESLint codebase (#&#8203;7987) (Teddy Katz)
- fbd7c13 Update: ensure operator-assignment handles exponentiation operators (#&#8203;7970) (Teddy Katz)
- c5066ce Update: add "variables" option to no-use-before-define (fixes #&#8203;7111) (#&#8203;7948) (Teddy Katz)
- 09546a4 New: `template-tag-spacing` rule (fixes #&#8203;7631) (#&#8203;7913) (Jonathan Wilsson)

---

### [`v3.16.0`](https://github.com/eslint/eslint/releases/v3.16.0)

- d89d0b4 Update: fix quotes false negative for string literals as template tags (#&#8203;8107) (Teddy Katz)
- 21be366 Chore: Ensuring eslint:recommended rules are sorted. (#&#8203;8106) (Kevin Partington)
- 360dbe4 Update: Improve error message when extend config missing (fixes #&#8203;6115) (#&#8203;8100) (alberto)
- f62a724 Chore: use updated token iterator methods (#&#8203;8103) (Kai Cataldo)
- daf6f26 Fix: check output in RuleTester when errors is a number (fixes #&#8203;7640) (#&#8203;8097) (alberto)
- cfb65c5 Update: make no-lone-blocks report blocks in switch cases (fixes #&#8203;8047) (#&#8203;8062) (Teddy Katz)
- 290fb1f Update: Add includeComments to getTokenByRangeStart (fixes #&#8203;8068) (#&#8203;8069) (Kai Cataldo)
- ff066dc Chore: Incorrect source code test text (#&#8203;8096) (Jack Ford)
- 14d146d Docs: Clarify --ext only works with directories (fixes #&#8203;7939) (#&#8203;8095) (alberto)
- 013a454 Docs: Add TSC meeting quorum requirement (#&#8203;8086) (Kevin Partington)
- 7516303 Fix: `sourceCode.getTokenAfter` shouldn't skip tokens after comments (#&#8203;8055) (Toru Nagashima)
- c53e034 Fix: unicode-bom fixer insert BOM in appropriate location (fixes #&#8203;8083) (#&#8203;8084) (pantosha)
- 55ac302 Chore: fix the timing to define rules for tests (#&#8203;8082) (Toru Nagashima)
- c7e64f3 Upgrade: mock-fs (#&#8203;8070) (Toru Nagashima)
- acc3301 Update: handle uncommon linebreaks consistently in rules (fixes #&#8203;7949) (#&#8203;8049) (Teddy Katz)
- 591b74a Chore: enable operator-linebreak on ESLint codebase (#&#8203;8064) (Teddy Katz)
- 6445d2a Docs: Add documentation for /\* exported */ (fixes #&#8203;7998) (#&#8203;8065) (Lee Yi Min)
- fcc38db Chore: simplify and improve performance for autofix (#&#8203;8035) (Toru Nagashima)
- b04fde7 Chore: improve performance of SourceCode constructor (#&#8203;8054) (Teddy Katz)
- 90fd555 Update: improve null detection in eqeqeq for ES6 regexes (fixes #&#8203;8020) (#&#8203;8042) (Teddy Katz)
- 16248e2 Fix: no-extra-boolean-cast incorrect Boolean() autofixing (fixes #&#8203;7977) (#&#8203;8037) (Jonathan Wilsson)
- 834f45d Update: rewrite TokenStore (fixes #&#8203;7810) (#&#8203;7936) (Toru Nagashima)
- 329dcdc Chore: unify checks for statement list parents (#&#8203;8048) (Teddy Katz)
- c596690 Docs: Clarify generator-star-spacing config example (fixes #&#8203;8027) (#&#8203;8034) (Hòa Trần)
- a11d4a6 Docs: fix a typo in shareable configs documentation (#&#8203;8036) (Dan Homola)
- 1e3d4c6 Update: add fixer for no-unused-labels (#&#8203;7841) (Teddy Katz)
- f47fb98 Update: ensure semi-spacing checks import/export declarations (#&#8203;8033) (Teddy Katz)
- e228d56 Update: no-undefined handles properties/classes/modules (fixes #&#8203;7964) (#&#8203;7966) (Kevin Partington)
- 7bc92d9 Chore: fix invalid test cases (#&#8203;8030) (Toru Nagashima)

---

### [`v3.16.1`](https://github.com/eslint/eslint/releases/v3.16.1)

- ff8a80c Fix: duplicated autofix output for inverted fix ranges (fixes #&#8203;8116) (#&#8203;8117) (Teddy Katz)
- a421897 Docs: fix typo in arrow-parens.md (#&#8203;8132) (Will Chen)
- 22d7fbf Chore: fix invalid redeclared variables in tests (#&#8203;8130) (Teddy Katz)
- 8d95598 Chore: fix output assertion typos in rule tests (#&#8203;8129) (Teddy Katz)
- 9fa2559 Docs: Add missing quotes in key-spacing rule (#&#8203;8121) (Glenn Reyes)
- f3a6ced Build: package.json update for eslint-config-eslint release (ESLint Jenkins)

---

### [`v3.17.0`](https://github.com/eslint/eslint/releases/v3.17.0)

* 4fdf6d7 Update: deprecate `applyDefaultPatterns` in `line-comment-position` (#&#8203;8183) (alberto)
* 25e5817 Fix: Don't autofix `+ +a` to `++a` in space-unary-ops (#&#8203;8176) (Alan Pierce)
* a6ce8f9 Build: Sort rules before dumping them to doc files (#&#8203;8154) (Danny Andrews)
* 0af9057 Chore: Upgrade to a patched version of mock-fs (fixes #&#8203;8177) (#&#8203;8188) (Teddy Katz)
* bf4d8cf Update: ignore eslint comments in lines-arount-comment (fixes #&#8203;4345) (#&#8203;8155) (alberto)
* dad20ad New: add SourceCode#getLocFromIndex and #getIndexFromLoc (fixes #&#8203;8073) (#&#8203;8158) (Teddy Katz)
* 18a519f Update: let RuleTester cases assert that no autofix occurs (fixes #&#8203;8157) (#&#8203;8163) (Teddy Katz)
* a30eb8d Docs: improve documentation for RuleTester cases (#&#8203;8162) (Teddy Katz)
* a78ec9f Chore: upgrade `coveralls` to ^2.11.16 (#&#8203;8161) (alberto)
* d02bd11 Fix: padded-blocks autofix problems with comments (#&#8203;8149) (alberto)
* 9994889 Docs: Add missing space to `create` in `no-use-before-define` (#&#8203;8166) (Justin Anastos)
* 4d542ba Docs: Remove unneeded statement about autofix (#&#8203;8164) (alberto)
* 20daea5 New: no-compare-neg-zero rule (#&#8203;8091) (薛定谔的猫)
* 4d35a81 Fix: Add a utility to avoid autofix conflicts (fixes #&#8203;7928, fixes #&#8203;8026) (#&#8203;8067) (Alan Pierce)
* 287e882 New: nonblock-statement-body-position rule (fixes #&#8203;6067) (#&#8203;8108) (Teddy Katz)
* 7f1f4e5 Chore: remove unneeded devDeps `linefix` and `gh-got` (#&#8203;8160) (alberto)
* ca1694b Update: ignore negative ranges in fixes (#&#8203;8133) (alberto)
* 163d751 Docs: `lines-around-comment` doesn't disallow empty lines (#&#8203;8151) (alberto)
* 1c84922 Chore: upgrade eslint-plugin-node (#&#8203;8156) (alberto)
* 1ee5c27 Fix: Make RuleTester handle empty-string cases gracefully (fixes #&#8203;8142) (#&#8203;8143) (Teddy Katz)
* 044bc10 Docs: Add details about "--fix" option for "sort-imports" rule (#&#8203;8077) (Olivier Audard)
* 3fec54a Add option to ignore property in no-param-reassign (#&#8203;8087) (Christian Bundy)
* 4e52cfc Fix: Improve keyword-spacing typescript support (fixes #&#8203;8110) (#&#8203;8111) (Reyad Attiyat)
* 7ff42e8 New: Allow regexes in RuleTester (fixes #&#8203;7837) (#&#8203;8115) (Daniel Lo Nigro)
* cbd7ded Build: display rules’ meta data in their docs (fixes #&#8203;5774) (#&#8203;8127) (Wilson Kurniawan)
* da8e8af Update: include function name in report message if possible (fixes #&#8203;7260) (#&#8203;8058) (Dieter Luypaert)
* 8f91e32 Fix: `ignoreRestSiblings` option didn't cover arguments (fixes #&#8203;8119) (#&#8203;8120) (Toru Nagashima)

---

### [`v3.17.1`](https://github.com/eslint/eslint/releases/v3.17.1)

* f8c8e6e Build: change mock-fs path without SSH (fixes #&#8203;8207) (#&#8203;8208) (Toru Nagashima)
* f713f11 Fix: nonblock-statement-body-position multiline error (fixes #&#8203;8202) (#&#8203;8203) (Teddy Katz)
* 41e3d9c Fix: `operator-assignment` with parenthesized expression (fixes #&#8203;8190) (#&#8203;8197) (alberto)
* 5e3bca7 Chore: add eslint-plugin-eslint-plugin (#&#8203;8198) (Teddy Katz)
* 580da36 Chore: add missing `output` property to tests (#&#8203;8195) (alberto)

---

### [`v3.18.0`](https://github.com/eslint/eslint/releases/v3.18.0)

* 85f74ca Fix: broken code path of direct nested loops (fixes #&#8203;8248) (#&#8203;8274) (Toru Nagashima)
* a61c359 Fix: Ignore hidden folders when resolving globs (fixes #&#8203;8259) (#&#8203;8270) (Ian VanSchooten)
* 6f05546 Chore: convert StubModuleResolver in config tests to ES6 class (#&#8203;8265) (Teddy Katz)
* 0c0fc31 Fix: false positive of no-extra-parens about spread and sequense (#&#8203;8275) (Toru Nagashima)
* e104973 Docs: remove self-reference in no-restricted-syntax docs (#&#8203;8277) (Vitor Balocco)
* 23eca51 Update: Add allowTaggedTemplates to no-unused-expressions (fixes #&#8203;7632) (#&#8203;8253) (Kevin Partington)
* f9ede3f Upgrade: doctrine to 2.0.0 (#&#8203;8269) (alberto)
* 1b678a6 New: allow rules to listen for AST selectors (fixes #&#8203;5407) (#&#8203;7833) (Teddy Katz)
* 63ca0c5 Chore: use precalculated counts in stylish formatter (#&#8203;8251) (alberto)
* 47c3171 Fix: typo in console.error (#&#8203;8258) (Jan Peer Stöcklmair)
* e74ed6d Chore: convert Traverser to ES6 class (refs #&#8203;7849) (#&#8203;8232) (Teddy Katz)
* 13eead9 Fix: sort-vars crash on mixed destructuring declarations (#&#8203;8245) (Teddy Katz)
* 133f489 Fix: func-name-matching crash on destructuring assignment to functions (#&#8203;8247) (Teddy Katz)
* a34b9c4 Fix: func-name-matching crash on non-string literal computed keys (#&#8203;8246) (Teddy Katz)
* 7276e6d Docs: remove unneeded semicolons in arrow-parens.md (#&#8203;8249) (Dmitry Gershun)
* 8c40a25 Upgrade: concat-stream known to be vulnerable prior 1.5.2 (#&#8203;8228) (Samuel)
* 149c055 Upgrade: mock-fs to v4.2.0 (fixes #&#8203;8194) (#&#8203;8243) (Teddy Katz)
* a83bff9 Build: remove unneeded json config in demo (fixes #&#8203;8237) (#&#8203;8242) (alberto)
* df12137 Docs: fix typos (#&#8203;8235) (Gyandeep Singh)
* b5e9788 Chore: rename no-extra-parens methods (#&#8203;8225) (Vitor Balocco)
* 7f8afe6 Update: no-extra-parens overlooked spread and superClass (fixes #&#8203;8175) (#&#8203;8209) (Toru Nagashima)
* ce6ff56 Docs: set recommended true for no-global-assign (fixes #&#8203;8215) (#&#8203;8218) (BinYi LIU)
* 5b5c236 Fix: wrong comment when module not found in config (fixes #&#8203;8192) (#&#8203;8196) (alberto)

---

### [`v3.19.0`](https://github.com/eslint/eslint/releases/v3.19.0)

* e09132f Fix: no-extra-parens false positive with exports and object literals (#&#8203;8359) (Teddy Katz)
* 91baed4 Update: allow custom messages in no-restricted-syntax (fixes #&#8203;8298) (#&#8203;8357) (Vitor Balocco)
* 35c93e6 Fix: prevent space-before-function-paren from checking type annotations (#&#8203;8349) (Teddy Katz)
* 3342e9f Fix: don't modify operator precedence in operator-assignment autofixer (#&#8203;8358) (Teddy Katz)
* f88375f Docs: clarify that no-unsafe-negation is in eslint:recommended (#&#8203;8371) (Teddy Katz)
* 02f0d27 Docs: Add soda0289 to Development Team (#&#8203;8367) (Kai Cataldo)
* 155424c Fix: ignore empty path in patterns (fixes #&#8203;8362) (#&#8203;8364) (alberto)
* 27616a8 Fix: prefer-const false positive with object spread (fixes #&#8203;8187) (#&#8203;8297) (Vitor Balocco)
* 8569a90 Docs: add note about git's linebreak handling to linebreak-style docs (#&#8203;8361) (Teddy Katz)
* 5878593 Chore: fix invalid syntax in no-param-reassign test (#&#8203;8360) (Teddy Katz)
* 1b1046b Fix: don't classify plugins that throw errors as "missing" (fixes #&#8203;6874) (#&#8203;8323) (Teddy Katz)
* 29f4ba5 Fix: no-useless-computed-key invalid autofix for getters and setters (#&#8203;8335) (Teddy Katz)
* 0541eaf Fix: no-implicit-coercion invalid autofix with consecutive identifiers (#&#8203;8340) (Teddy Katz)
* 41b9786 Fix: no-extra-parens false positive with objects following arrows (#&#8203;8339) (Teddy Katz)
* 3146167 Fix: `eslint.verify` should not mutate config argument (fixes #&#8203;8329) (#&#8203;8334) (alberto)
* 927de90 Fix: dot-notation autofix produces invalid syntax for integer properties (#&#8203;8332) (Teddy Katz)
* a9d1bea Fix: comma-style autofix produces errors on parenthesized elements (#&#8203;8331) (Teddy Katz)
* d52173f Fix: don't generate invalid options in config-rule (#&#8203;8326) (Teddy Katz)
* 6eda3b5 Fix: no-extra-parens invalid autofix in for-of statements (#&#8203;8337) (Teddy Katz)
* 6c819d8 Fix: dot-notation autofix produces errors on parenthesized computed keys (#&#8203;8330) (Teddy Katz)
* 2d883d7 Fix: object-shorthand autofix produces errors on parenthesized functions (#&#8203;8328) (Teddy Katz)
* cd9b774 Fix: quotes false positive with backtick option in method names (#&#8203;8327) (Teddy Katz)
* d064ba2 Fix: no-else-return false positive for ifs in single-statement position (#&#8203;8338) (Teddy Katz)
* 6a718ba Chore: enable max-statements-per-line on ESLint codebase (#&#8203;8321) (Teddy Katz)
* 614b62e Chore: update sinon calls to deprecated API. (#&#8203;8310) (alberto)
* 0491572 Chore: use precalculated counts in codeframe formatter (#&#8203;8296) (Vitor Balocco)
* 8733e6a Chore: Fix incorrect error location properties in tests (#&#8203;8307) (alberto)
* c4ffb49 Chore: Fix typos in test option assertions (#&#8203;8305) (Teddy Katz)
* 79a97cb Upgrade: devDependencies (#&#8203;8303) (alberto)
* e4da200 Upgrade: Mocha to 3.2.0 (#&#8203;8299) (Ilya Volodin)
* 2f144ca Fix: operator-assignment autofix errors with parentheses (fixes #&#8203;8293) (#&#8203;8294) (Teddy Katz)
* 7521cd5 Chore: update token logic in rules to use ast-utils (#&#8203;8288) (Teddy Katz)
* 9b509ce Chore: refactor space-before-function-paren rule (#&#8203;8284) (Teddy Katz)
* ddc6350 Fix: no-param-reassign false positive on destructuring (fixes #&#8203;8279) (#&#8203;8281) (Teddy Katz)
* f8176b3 Chore: improve test coverage for node-event-generator (#&#8203;8287) (Teddy Katz)
* 602e9c2 Docs: fix incorrect selector examples (#&#8203;8278) (Teddy Katz)

---

### [`v4.0.0`](https://github.com/eslint/eslint/releases/v4.0.0)

* 4aefb49 Chore: avoid using deprecated rules on ESLint codebase (#&#8203;8708) (Teddy Katz)
* 389feba Chore: upgrade deps. (#&#8203;8684) (薛定谔的猫)
* 3da7b5e Fix: Semi-Style only check for comments when tokens exist (fixes #&#8203;8696) (#&#8203;8697) (Reyad Attiyat)
* 3cfe9ee Fix: Add space between async and param on fix (fixes #&#8203;8682) (#&#8203;8693) (Reyad Attiyat)
* c702858 Chore: enable no-multiple-empty-lines on ESLint codebase (#&#8203;8694) (Teddy Katz)
* 34c4020 Update: Add support for parens on left side for-loops (fixes: #&#8203;8393) (#&#8203;8679) (Victor Hom)
* 735cd09 Docs: Correct the comment in an example for `no-mixed-requires` (#&#8203;8686) (Fangzhou Li)
* 026f048 Chore: remove dead code from prefer-const (#&#8203;8683) (Teddy Katz)

---

### [`v4.1.0`](https://github.com/eslint/eslint/releases/v4.1.0)

* e8f1362 Docs: Remove wrong descriptions in `padded-block` rule (#&#8203;8783) (Plusb Preco)
* 291a783 Update: `enforceForArrowConditionals` to `no-extra-parens` (fixes #&#8203;6196) (#&#8203;8439) (Evilebot Tnawi)
* a21dd32 New: Add `overrides`/`files` options for glob-based config (fixes #&#8203;3611) (#&#8203;8081) (Sylvan Mably)
* 879688c Update: Add ignoreComments option to no-trailing-spaces (#&#8203;8061) (Jake Roussel)
* b58ae2e Chore: Only instantiate fileEntryCache when cache flage set (perf) (#&#8203;8763) (Gyandeep Singh)
* 9851288 Update: fix indent errors on multiline destructure (fixes #&#8203;8729) (#&#8203;8756) (Victor Hom)
* 3608f06 Docs: Increase visibility of code of conduct (fixes #&#8203;8758) (#&#8203;8764) (Kai Cataldo)
* 673a58b Update: support multiple fixes in a report (fixes #&#8203;7348) (#&#8203;8101) (Toru Nagashima)
* 7a1bc38 Fix: don't pass default parserOptions to custom parsers (fixes #&#8203;8744) (#&#8203;8745) (Teddy Katz)
* c5b4052 Chore: enable computed-property-spacing on ESLint codebase (#&#8203;8760) (Teddy Katz)
* 3419f64 Docs: describe how to use formatters on the formatter demo page (#&#8203;8754) (Teddy Katz)
* a3ff8f2 Chore: combine tests in tests/lib/eslint.js and tests/lib/linter.js (#&#8203;8746) (Teddy Katz)
* b7cc1e6 Fix: Space-infix-ops should ignore type annotations in TypeScript (#&#8203;8341) (Reyad Attiyat)
* 46e73ee Fix: eslint --init installs wrong dependencies of popular styles (fixes #&#8203;7338) (#&#8203;8713) (Toru Nagashima)
* a82361b Chore: Prevent package-lock.json files from being created (fixes #&#8203;8742) (#&#8203;8747) (Teddy Katz)
* 5f81a68 New: Add eslintIgnore support to package.json (fixes #&#8203;8458) (#&#8203;8690) (Victor Hom)
* b5a70b4 Update: fix multiline binary operator/parentheses indentation (#&#8203;8719) (Teddy Katz)
* ab8b016 Update: fix MemberExpression indentation with "off" option (fixes #&#8203;8721) (#&#8203;8724) (Teddy Katz)
* eb5d12c Update: Add Fixer method to Linter API (#&#8203;8631) (Gyandeep Singh)
* 26a2daa Chore: Cache fs reads in ignored-paths (fixes #&#8203;8363) (#&#8203;8706) (Victor Hom)

---

### [`v4.1.1`](https://github.com/eslint/eslint/releases/v4.1.1)

* f307aa0 Fix: ensure configs from a plugin are cached separately (fixes #&#8203;8792) (#&#8203;8798) (Teddy Katz)
* 8b48ae8 Docs: Add doc on parser services (fixes #&#8203;8390) (#&#8203;8795) (Victor Hom)
* 0d041e7 Fix: avoid crashing when using baseConfig with extends (fixes #&#8203;8791) (#&#8203;8797) (Teddy Katz)
* 03213bb Chore: improve comment explanation of `indent` internal functions (#&#8203;8800) (Teddy Katz)
* d2e88ed Chore: Fix misleading comment in ConfigCache.js (#&#8203;8799) (Teddy Katz)

---

### [`v4.2.0`](https://github.com/eslint/eslint/releases/v4.2.0)

* e0f0101 Update: fix indentation of nested function parameters (fixes #&#8203;8892) (#&#8203;8900) (Teddy Katz)
* 9f95a3e Chore: remove unused helper method from `indent` (#&#8203;8901) (Teddy Katz)
* 11ffe6b Fix: no-regex-spaces rule incorrectly fixes quantified spaces (#&#8203;8773) (Keri Warr)
* 975dacf Update: fix indentation of EmptyStatements (fixes #&#8203;8882) (#&#8203;8885) (Teddy Katz)
* 88ed041 Build: Turnoff CI branch build (fixes #&#8203;8804) (#&#8203;8873) (Gyandeep Singh)
* 72f22eb Chore: replace is-my-json-valid with Ajv (#&#8203;8852) (Gajus Kuizinas)
* 7c8de92 Docs: Clarified PR guidelines in maintainer guide (#&#8203;8876) (Kevin Partington)
* d1fc408 Docs: Update CLA link in Contributing docs (#&#8203;8883) (Calvin Freitas)
* 931a9f1 Fix: indent false positive with multi-line await expression (#&#8203;8837) (薛定谔的猫)
* 3767cda Update: add no-sync option to allow at root level (fixes #&#8203;7985) (#&#8203;8859) (Victor Hom)
* 1ce553d Docs: Fix wording of minProperties in object-curly-newline (fixes #&#8203;8874) (#&#8203;8878) (solmsted)
* f00854e Fix: --quiet no longer fixes warnings (fixes #&#8203;8675) (#&#8203;8858) (Kevin Partington)
* b678535 Chore: Add collapsible block for config in ISSUE_TEMPLATE (#&#8203;8872) (Gyandeep Singh)
* 1f5bfc2 Update: Add always-multiline option to multiline-ternary (fixes #&#8203;8770) (#&#8203;8841) (Nathan Woltman)
* 22116f2 Fix: correct comma-dangle JSON schema (#&#8203;8864) (Evgeny Poberezkin)
* 676af9e Update: fix indentation of JSXExpressionContainer contents (fixes #&#8203;8832) (#&#8203;8850) (Teddy Katz)
* 330dd58 Chore: fix title of linter test suite (#&#8203;8861) (Teddy Katz)
* 60099ed Chore: enable for-direction rule on ESLint codebase (#&#8203;8853) (薛定谔的猫)
* e0d1a84 Chore: upgrade eslint-plugin-eslint-plugin & eslint-plugin-node (#&#8203;8856) (薛定谔的猫)
* 0780d86 Chore: remove identical tests (#&#8203;8851) (Teddy Katz)
* 5c3ac8e Fix: arrow-parens fixer gets tripped up with trailing comma in args (#&#8203;8838) (薛定谔的猫)
* c4f2e29 Build: fix race condition in demo (#&#8203;8827) (Teddy Katz)
* c693be5 New: Allow passing a function as `fix` option (fixes #&#8203;8039) (#&#8203;8730) (Ian VanSchooten)
* 8796d55 Docs: add missing item to 4.0 migration guide table of contents (#&#8203;8835) (薛定谔的猫)
* 742998c doc md update: false -> `false` (#&#8203;8825) (Erik Vold)
* ce969f9 Docs: add guidelines for patch release communication (fixes #&#8203;7277) (#&#8203;8823) (Teddy Katz)
* 5c83c99 Docs: Clarify arrow function parens in no-extra-parens (fixes #&#8203;8741) (#&#8203;8822) (Kevin Partington)
* 84d921d Docs: Added note about Node/CJS scoping to no-redeclare (fixes #&#8203;8814) (#&#8203;8820) (Kevin Partington)
* 85c9327 Update: fix parenthesized CallExpression indentation (fixes #&#8203;8790) (#&#8203;8802) (Teddy Katz)
* be8d354 Update: simplify variable declarator indent handling (fixes #&#8203;8785) (#&#8203;8801) (Teddy Katz)
* 9417818 Fix: no-debugger autofixer produced invalid syntax (#&#8203;8806) (Teddy Katz)
* 8698a92 New: getter-return rule (fixes #&#8203;8449) (#&#8203;8460) (薛定谔的猫)
* eac06f2 Fix: no-extra-parens false positives for variables called "let" (#&#8203;8808) (Teddy Katz)
* 616587f Fix: dot-notation autofix produces syntax errors for object called "let" (#&#8203;8807) (Teddy Katz)
* a53ef7e Fix: don't require a third argument in linter.verifyAndFix (fixes #&#8203;8805) (#&#8203;8809) (Teddy Katz)
* 5ad8b70 Docs: add minor formatting improvement to paragraph about parsers (#&#8203;8816) (Teddy Katz)

---

### [`v4.3.0`](https://github.com/eslint/eslint/releases/v4.3.0)

* 91dccdf Update: support more options in prefer-destructuring (#&#8203;8796) (Victor Hom)
* 3bebcfd Update: Support generator yields in no constant condition (#&#8203;8762) (Victor Hom)
* 96df8c9 Fix: Handle fixing objects containing comments (fixes #&#8203;8484) (#&#8203;8944) (Brian Schemp)
* e39d41d Docs: Make `peerDependencies` package.json snippet valid JSON (#&#8203;8971) (Sam Adams)
* a5fd101 Fix: duplicated error message if a crash occurs (fixes #&#8203;8964) (#&#8203;8965) (Teddy Katz)
* f8d122c Docs: trailing commas not allowed in json (#&#8203;8969) (Scott Fletcher)
* d09288a Chore: Use `output: null` to assert that a test case is not autofixed. (#&#8203;8960) (薛定谔的猫)
* e639358 Update: add question to confirm downgrade (fixes #&#8203;8870) (#&#8203;8911) (Toru Nagashima)
* 601039d Docs: fix badge in eslint-config-eslint readme (#&#8203;8954) (Teddy Katz)
* 3c231fa Update: add enforceInMethodNames to no-underscore-dangle (fixes #&#8203;7065) (#&#8203;7234) (Gabriele Petronella)
* 128591f Update: prefer-numeric-literals warns Number.parseInt (fixes #&#8203;8913) (#&#8203;8929) (Kevin Partington)
* 846f8b1 Docs: Clarified that core PRs require issue in maintainer guide (#&#8203;8927) (Kevin Partington)
* 55bc35d Fix: Avoid shell mangling during eslint --init (#&#8203;8936) (Anders Kaseorg)
* 10c3d78 Chore: fix misleading `indent` test (#&#8203;8925) (Teddy Katz)
* fb8005d Update: no-restricted-globals custom error messages (fixes #&#8203;8315) (#&#8203;8932) (Kevin Partington)
* a747b6f Chore: make minor improvements to `indent` internals (#&#8203;8947) (Teddy Katz)
* 1ea3723 Update: fix indentation of parenthesized MemberExpressions (fixes #&#8203;8924) (#&#8203;8928) (Teddy Katz)
* 9abc6f7 Update: fix BinaryExpression indentation edge case (fixes #&#8203;8914) (#&#8203;8930) (Teddy Katz)
* 0e90453 Docs: Fixing broken cyclomatic complexity link (fixes #&#8203;8396) (#&#8203;8937) (Chris Bargren)
* a8a8350 Chore: improve performance of `indent` rule (#&#8203;8905) (Teddy Katz)
* 764b2a9 Chore: update header info in `indent` (#&#8203;8926) (Teddy Katz)
* 597c217 Fix: confusing error if plugins from config is not an array (#&#8203;8888) (Calvin Freitas)
* 3c1dd6d Docs: add description of no-sync `allowAtRootLevel` option (fixes #&#8203;8902) (#&#8203;8906) (Teddy Katz)
* 933a9cf Chore: add a fuzzer to detect bugs in core rules (#&#8203;8422) (Teddy Katz)
* 45f8cd9 Docs: fix verifyAndFix result property name (#&#8203;8903) (Tino Vyatkin)
* 1a89e1c Docs: Fix always-multiline example in multiline-ternary docs (#&#8203;8904) (Nathan Woltman)

---

### [`v4.4.0`](https://github.com/eslint/eslint/releases/v4.4.0)

* 89196fd Upgrade: Espree to 3.5.0 (#&#8203;9074) (Gyandeep Singh)
* b3e4598 Fix: clarify AST and don't use `node.start`/`node.end` (fixes #&#8203;8956) (#&#8203;8984) (Toru Nagashima)
* 62911e4 Update: Add ImportDeclaration option to indent rule (#&#8203;8955) (David Irvine)
* de75f9b Chore: enable object-curly-newline & object-property-newline.(fixes #&#8203;9042) (#&#8203;9068) (薛定谔的猫)
* 5ae8458 Docs: fix typo in object-shorthand.md (#&#8203;9066) (Jon Berry)
* c3d5b39 Docs: clarify options descriptions (fixes #&#8203;8875) (#&#8203;9060) (Brandon Mailhiot)
* 37158c5 Docs: clarified behavior of globalReturn option (fixes #&#8203;8953) (#&#8203;9058) (Brandon Mailhiot)
* c2f3553 Docs: Update example for MemberExpression option of indent (fixes #&#8203;9056) (#&#8203;9057) (Jeff)
* 78a85e0 Fix: no-extra-parens incorrectly reports async function expressions (#&#8203;9035) (薛定谔的猫)
* c794f86 Fix: getter-return reporting method named 'get' (fixes #&#8203;8919) (#&#8203;9004) (薛定谔的猫)
* d0f78ec Docs: update rule deprecation policy (fixes #&#8203;8635) (#&#8203;9033) (Teddy Katz)
* 5ab282f Fix: Print error message in bin/eslint.js (fixes #&#8203;9011) (#&#8203;9041) (Victor Hom)
* 50e3cf3 Docs: Update sort-keys doc to define natural ordering (fixes #&#8203;9043) (#&#8203;9045) (Karan Sharma)
* 7ecfe6a Chore: enable eslint-plugin/test-case-property-ordering (#&#8203;9040) (薛定谔的猫)
* ad32697 Upgrade: js-yaml to 3.9.1 (refs #&#8203;9011) (#&#8203;9044) (Teddy Katz)
* 66c1d43 Docs: Create SUPPORT.md (#&#8203;9031) (Teddy Katz)
* 7247b6c Update: handle indentation of custom destructuring syntax (fixes #&#8203;8990) (#&#8203;9027) (Teddy Katz)
* cdb82f2 Fix: padding-line-between-statements crash on semicolons after blocks (#&#8203;8748) (Alexander Madyankin)
* 3141872 Chore: remove unnecessary eslint-disable comments in codebase (#&#8203;9032) (Teddy Katz)
* 0f97279 Fix: refactor no-multi-spaces to avoid regex backtracking (fixes #&#8203;9001) (#&#8203;9008) (Teddy Katz)
* b74514d Fix: refactor RuleContext to not modify report locations (fixes #&#8203;8980) (#&#8203;8997) (Teddy Katz)
* 31d7fd2 Fix: inconsistent `indent` behavior on computed properties (fixes #&#8203;8989) (#&#8203;8999) (Teddy Katz)
* 3393894 Fix: avoid reporting the entire AST for missing rules (#&#8203;8998) (Teddy Katz)
* b3b95b8 Chore: enable additional rules on ESLint codebase (#&#8203;9013) (Teddy Katz)
* 9b6c552 Upgrade: eslint-plugin-eslint-plugin@&#8203;0.8.0 (#&#8203;9012) (薛定谔的猫)
* acbe86a Chore: disallow .substr and .substring in favor of .slice (#&#8203;9010) (Teddy Katz)
* d0536d6 Chore: Optimizes adding Linter methods (fixes #&#8203;9000) (#&#8203;9007) (Sean C Denison)
* 0a0401f Chore: fix spelling error. (#&#8203;9003) (薛定谔的猫)
* 3d020b9 Update: emit a warning for ecmaFeatures rather than throwing an error (#&#8203;8974) (Teddy Katz)
* d2f8f9f Fix: include name of invalid config in validation messages (fixes #&#8203;8963) (#&#8203;8973) (Teddy Katz)
* c3ee46b Chore: fix misleading comment in RuleTester (#&#8203;8995) (Teddy Katz)

---

### [`v4.4.1`](https://github.com/eslint/eslint/releases/v4.4.1)

* ec93614 Fix: no-multi-spaces to avoid reporting consecutive tabs (fixes #&#8203;9079) (#&#8203;9087) (Teddy Katz)

---

### [`v4.5.0`](https://github.com/eslint/eslint/releases/v4.5.0)

* decdd2c Update: allow arbitrary nodes to be ignored in `indent` (fixes #&#8203;8594) (#&#8203;9105) (Teddy Katz)
* 79062f3 Update: fix indentation of multiline `new.target` expressions (#&#8203;9116) (Teddy Katz)
* d00e24f Upgrade: `chalk` to 2.x release (#&#8203;9115) (Stephen Edgar)
* 6ef734a Docs: add missing word in processor documentation (#&#8203;9106) (Teddy Katz)
* a4f53ba Fix: Include files with no messages in junit results (#&#8203;9093) (#&#8203;9094) (Sean DuBois)
* 1d6a9c0 Chore: enable eslint-plugin/test-case-shorthand-strings (#&#8203;9067) (薛定谔的猫)
* f8add8f Fix: don't autofix with linter.verifyAndFix when `fix: false` is used (#&#8203;9098) (Teddy Katz)
* 77bcee4 Docs: update instructions for adding TSC members (#&#8203;9086) (Teddy Katz)
* bd09cd5 Update: avoid requiring NaN spaces of indentation (fixes #&#8203;9083) (#&#8203;9085) (Teddy Katz)
* c93a853 Chore: Remove extra space in blogpost template (#&#8203;9088) (Kai Cataldo)

---

### [`v4.6.0`](https://github.com/eslint/eslint/releases/v4.6.0)

* 56dd769 Docs: fix link format in prefer-arrow-callback.md (#&#8203;9198) (Vse Mozhet Byt)
* 6becf91 Update: add eslint version to error output. (fixes #&#8203;9037) (#&#8203;9071) (薛定谔的猫)
* 0e09973 New: function-paren-newline rule (fixes #&#8203;6074) (#&#8203;8102) (Teddy Katz)
* 88a64cc Chore: Make parseJsonConfig() a pure function in Linter (#&#8203;9186) (Teddy Katz)
* 1bbac51 Fix: avoid breaking eslint-plugin-eslint-comments (fixes #&#8203;9193) (#&#8203;9196) (Teddy Katz)
* 3e8b70a Fix: off-by-one error in eslint-disable comment checking (#&#8203;9195) (Teddy Katz)
* 73815f6 Docs: rewrite prefer-arrow-callback documentation (fixes #&#8203;8950) (#&#8203;9077) (Charles E. Morgan)
* 0d3a854 Chore: avoid mutating report descriptors in report-translator (#&#8203;9189) (Teddy Katz)
* 2db356b Update: no-unused-vars Improve message to include the allowed patterns (#&#8203;9176) (Eli White)
* 8fbaf0a Update: Add configurability to generator-star-spacing (#&#8203;8985) (Ethan Rutherford)
* 8ed779c Chore: remove currentScopes property from Linter instances (refs #&#8203;9161) (#&#8203;9187) (Teddy Katz)
* af4ad60 Fix: Handle error when running init without npm (#&#8203;9169) (Gabriel Aumala)
* 4b94c6c Chore: make parse() a pure function in Linter (refs #&#8203;9161) (#&#8203;9183) (Teddy Katz)
* 1be5634 Chore: don't make Linter a subclass of EventEmitter (refs #&#8203;9161) (#&#8203;9177) (Teddy Katz)
* e95af9b Chore: don't include internal test helpers in npm package (#&#8203;9160) (Teddy Katz)
* 6fb32e1 Chore: avoid using private Linter APIs in astUtils tests (refs #&#8203;9161) (#&#8203;9173) (Teddy Katz)
* de6dccd Docs: add documentation for Linter methods (refs #&#8203;6525) (#&#8203;9151) (Teddy Katz)
* 2d90030 Chore: remove unused assignment. (#&#8203;9182) (薛定谔的猫)
* d672aef Chore: refactor reporting logic (refs #&#8203;9161) (#&#8203;9168) (Teddy Katz)
* 5ab0434 Fix: indent crash on sparse arrays with "off" option (fixes #&#8203;9157) (#&#8203;9166) (Teddy Katz)
* c147b97 Chore: Make SourceCodeFixer accept text instead of a SourceCode instance (#&#8203;9178) (Teddy Katz)
* f127423 Chore: avoid using private Linter APIs in Linter tests (refs #&#8203;9161) (#&#8203;9175) (Teddy Katz)
* 2334335 Chore: avoid using private Linter APIs in SourceCode tests (refs #&#8203;9161) (#&#8203;9174) (Teddy Katz)
* 2dc243a Chore: avoid using internal Linter APIs in RuleTester (refs #&#8203;9161) (#&#8203;9172) (Teddy Katz)
* d6e436f Fix: no-extra-parens reported some parenthesized IIFEs (fixes #&#8203;9140) (#&#8203;9158) (Teddy Katz)
* e6b115c Build: Add an edit link to the rule docs’ metadata (#&#8203;9049) (Jed Fox)
* fcb7bb4 Chore: avoid unnecessarily complex forEach calls in no-extra-parens (#&#8203;9159) (Teddy Katz)
* ffa021e Docs: quotes rule - when does \n require backticks (#&#8203;9135) (avimar)
* 60c5148 Chore: improve coverage in lib/*.js (#&#8203;9130) (Teddy Katz)

---

### [`v4.6.1`](https://github.com/eslint/eslint/releases/v4.6.1)

* bdec46d Build: avoid process leak when generating website (#&#8203;9217) (Teddy Katz)
* cb74b87 Fix: avoid adding globals when an env is used with `false` (fixes #&#8203;9202) (#&#8203;9203) (Teddy Katz)
* f9b7544 Docs: Correct a typo in generator-star-spacing documentation (#&#8203;9205) (Ethan Rutherford)
* e5c5e83 Build: Fixing issue with docs generation (Fixes #&#8203;9199) (#&#8203;9200) (Ilya Volodin)

---

### [`v4.7.0`](https://github.com/eslint/eslint/releases/v4.7.0)

* 787b78b Upgrade: Espree v3.5.1 (fixes #&#8203;9153) (#&#8203;9314) (Brandon Mills)
* 1488b51 Update: run rules after `node.parent` is already set (fixes #&#8203;9122) (#&#8203;9283) (Teddy Katz)
* 4431d68 Docs: fix wrong config in max-len example. (#&#8203;9309) (薛定谔的猫)
* 7d24dde Docs: Fix code snippet to refer to the correct option (#&#8203;9313) (Ruben Tytgat)
* 12388d4 Chore: rewrite parseListConfig for a small perf gain. (#&#8203;9300) (薛定谔的猫)
* ce1f084 Update: fix MemberExpression handling in no-extra-parens (fixes #&#8203;9156) (jackyho112)
* 0c720a3 Update: allow autofixing when using processors (fixes #&#8203;7510) (#&#8203;9090) (Teddy Katz)
* 838df76 Chore: upgrade deps. (#&#8203;9289) (薛定谔的猫)
* f12def6 Update: indent flatTernary option to handle `return` (fixes #&#8203;9285) (#&#8203;9296) (Teddy Katz)
* e220687 Fix: remove autofix for var undef inits (fixes #&#8203;9231) (#&#8203;9288) (Victor Hom)
* 002e199 Docs: fix no-restricted-globals wrong config. (#&#8203;9305) (薛定谔的猫)
* fcfe91a Docs: fix wrong config in id-length example. (#&#8203;9303) (薛定谔的猫)
* 2731f94 Update: make newline-per-chained-call fixable (#&#8203;9149) (João Granado)
* 61f1093 Chore: avoid monkeypatching Linter instances in RuleTester (#&#8203;9276) (Teddy Katz)
* 28929cb Chore: remove Linter#reset (refs #&#8203;9161) (#&#8203;9268) (Teddy Katz)
* abc8634 Build: re-run browserify when generating site (#&#8203;9275) (Teddy Katz)
* 7685fed Fix: IIFE and arrow functions in no-invalid-this (fixes #&#8203;9126) (#&#8203;9258) (Toru Nagashima)
* 2b1eba2 Chore: enable eslint-plugin/no-deprecated-context-methods (#&#8203;9279) (Teddy Katz)
* 981f933 Fix: reuse the AST of source code object in verify (#&#8203;9256) (Toru Nagashima)
* cd698ba Docs: move RuleTester documentation to Node.js API page (#&#8203;9273) (Teddy Katz)
* 4ae7ad3 Docs: fix inaccuracy in `npm run perf` description (#&#8203;9274) (Teddy Katz)
* cad45bd Docs: improve documentation for rule contexts (#&#8203;9272) (Teddy Katz)
* 3b0c6fd Chore: remove extraneous linter properties (refs #&#8203;9161) (#&#8203;9267) (Teddy Katz)
* c3231b3 Docs: Fix typo in array-bracket-newline.md (#&#8203;9269) (宋文强)
* 51132d6 Fix: Formatters keep trailing '.' if preceded by a space (fixes #&#8203;9154) (#&#8203;9247) (i-ron-y)
* 88d5d4d Chore: remove undocumented Linter#markVariableAsUsed method (refs #&#8203;9161) (#&#8203;9266) (Teddy Katz)
* 09414cf Chore: remove internal Linter#getDeclaredVariables method (refs #&#8203;9161) (#&#8203;9264) (Teddy Katz)
* f31f59d Chore: prefer smaller scope for variables in codebase (#&#8203;9265) (Teddy Katz)
* 3693e4e Chore: remove undocumented Linter#getScope method (#&#8203;9253) (Teddy Katz)
* 5d7eb81 Chore: refactor config hash caching in CLIEngine (#&#8203;9260) (Teddy Katz)
* 1a76c4d Chore: remove SourceCode passthroughs from Linter.prototype (refs #&#8203;9161) (#&#8203;9263) (Teddy Katz)
* 40ae27b Chore: avoid relying on Linter#getScope/markVariableAsUsed in tests (#&#8203;9252) (Teddy Katz)
* b383d81 Chore: make executeOnFile a pure function in CLIEngine (#&#8203;9262) (Teddy Katz)
* 5e0e579 Chore: avoid internal SourceCode methods in Linter tests (refs #&#8203;9161) (#&#8203;9223) (Teddy Katz)
* adab827 Chore: remove unused eslint-disable comment (#&#8203;9251) (Teddy Katz)
* 31e4ec8 Chore: use consistent names for apply-disable-directives in tests (#&#8203;9246) (Teddy Katz)
* 7ba46e6 Fix: shebang error in eslint-disable-new-line; add tests (fixes #&#8203;9238) (#&#8203;9240) (i-ron-y)
* 8f6546c Chore: remove undocumented defaults() method (refs #&#8203;9161) (#&#8203;9237) (Teddy Katz)
* 82d8b73 Docs: Fix error in example code for sort-imports (fixes #&#8203;8734) (#&#8203;9245) (i-ron-y)
* a32ec36 Update: refactor eslint-disable comment processing (#&#8203;9216) (Teddy Katz)
* 583f0b8 Chore: avoid using globals in CLIEngine tests (#&#8203;9242) (Teddy Katz)
* c8bf687 Chore: upgrade eslint-plugin-eslint-plugin@&#8203;1.0.0 (#&#8203;9234) (薛定谔的猫)
* 3c41a05 Chore: always normalize rules to new API in rules.js (#&#8203;9236) (Teddy Katz)
* c5f4227 Chore: move logic for handling missing rules to rules.js (#&#8203;9235) (Teddy Katz)
* bf1e344 Chore: create report translators lazily (#&#8203;9221) (Teddy Katz)
* 2eedc1f Chore: remove currentFilename prop from Linter instances (refs #&#8203;9161) (#&#8203;9219) (Teddy Katz)
* 5566e94 Docs: Replace misleading CLA links (#&#8203;9133) (#&#8203;9232) (i-ron-y)
* c991630 Chore: remove ConfigOps.normalize in favor of ConfigOps.getRuleSeverity (#&#8203;9224) (Teddy Katz)
* 171962a Chore: remove internal Linter#getAncestors helper (refs #&#8203;9161) (#&#8203;9222) (Teddy Katz)
* a567499 Chore: avoid storing list of problems on Linter instance (refs #&#8203;9161) (#&#8203;9214) (Teddy Katz)
* ed6d088 Chore: avoid relying on undocumented Linter#getFilename API in tests (#&#8203;9218) (Teddy Katz)

---

### [`v4.7.1`](https://github.com/eslint/eslint/releases/v4.7.1)

* 08656db Fix: Handle nested disable directive correctly (fixes #&#8203;9318) (#&#8203;9322) (Gyandeep Singh)
* 9226495 Revert "Chore: rewrite parseListConfig for a small perf gain." (#&#8203;9325) (薛定谔的猫)

---

### [`v4.7.2`](https://github.com/eslint/eslint/releases/v4.7.2)

* 4f87732 Fix: Revert setting node.parent early (fixes #&#8203;9331) (#&#8203;9336) (Teddy Katz)

---

### [`v4.8.0`](https://github.com/eslint/eslint/releases/v4.8.0)

* 3f2b908 New: add option to report unused eslint-disable directives (fixes #&#8203;9249) (#&#8203;9250) (Teddy Katz)
* ff2be59 Fix: dot notation rule failing to catch string template (fixes #&#8203;9350) (#&#8203;9357) (Phil Quinn)
* b1372da Chore: remove sourceCode property from Linter (refs #&#8203;9161) (#&#8203;9363) (Teddy Katz)
* cef6f8c Docs: remove line about removing rules from semver policy (#&#8203;9367) (Teddy Katz)
* 06efe87 Fix: Add meta element with charset attribute. (#&#8203;9365) (H1Gdev)
* 458ca67 Docs: update architecture page (fixes #&#8203;9337) (#&#8203;9345) (Victor Hom)
* 1c6bc67 Fix: special EventEmitter keys leak information about other rules (#&#8203;9328) (Teddy Katz)
* d593e61 Docs: update eslint.org links to use https (#&#8203;9358) (Teddy Katz)
* 38d0cb2 Fix: fix wrong code-path about try-for-in (fixes #&#8203;8848) (#&#8203;9348) (Toru Nagashima)
* 434d9e2 Fix: Invalid font-size property value issue. (#&#8203;9341) (H1Gdev)
* a7668c2 Chore: Remove unnecessary slice from logging utility (#&#8203;9343) (Gyandeep Singh)
* 2ff6fb6 Chore: remove unused arguments in codebase (#&#8203;9340) (Teddy Katz)

---

### [`v4.9.0`](https://github.com/eslint/eslint/releases/v4.9.0)

* 85388fb Fix: Correct error and test messages to fit config search path (#&#8203;9428) (Jonathan Pool)
* 62a323c Fix: Add class options for `lines-around-comment` (fixes #&#8203;8564) (#&#8203;8565) (Ed Lee)
* 8eb4aae New: multiline-comment-style rule (fixes #&#8203;8320) (#&#8203;9389) (薛定谔的猫)
* db41408 Chore: avoid applying eslint-env comments twice (#&#8203;9278) (Teddy Katz)
* febb897 Chore: avoid loose equality assertions (#&#8203;9415) (Teddy Katz)
* 2247efa Update: Add FunctionExpression to require-jsdoc (fixes #&#8203;5867) (#&#8203;9395) (Kai Cataldo)
* 6791d18 Docs: Corrected noun to verb. (#&#8203;9438) (Jonathan Pool)
* b02fbb6 Update: custom messages for no-restricted-* (refs #&#8203;8400) (Maja Wichrowska)
* 02732bd Docs: Reorganized to avoid misunderstandings. (#&#8203;9434) (Jonathan Pool)
* d9466b8 Docs: Correct time forecast for tests. (#&#8203;9432) (Jonathan Pool)
* f7ed84f Docs: Add instruction re home-directory config files (refs #&#8203;7729) (#&#8203;9426) (Jonathan Pool)
* 30d018b Chore: Add Aladdin-ADD & VictorHom to README (#&#8203;9424) (Kai Cataldo)
* 2d8a303 Docs: fix examples for prefer-numeric-literals (#&#8203;9155) (Lutz Lengemann)
* d7610f5 Docs: Add jquery warning to prefer-destructuring (#&#8203;9409) (Thomas Grainger)
* e835dd1 Docs: clarify no-mixed-operators (fixes #&#8203;8051) (Ruxandra Fediuc)
* 51360c8 Docs: update block-spacing details (fixes #&#8203;8743) (#&#8203;9375) (Victor Hom)
* 6767857 Update: fix ignored nodes in indent rule when using tabs (fixes #&#8203;9392) (#&#8203;9393) (Robin Houston)
* 37dde77 Chore: Refactor SourceCode#getJSDocComment (#&#8203;9403) (Kai Cataldo)
* 9fedd51 Chore: Add missing space in blog post template (#&#8203;9407) (Kevin Partington)
* 7654c99 Docs: add installing prerequisites in readme. (#&#8203;9401) (薛定谔的猫)
* 786cc73 Update: Add "consistent" option to array-bracket-newline (fixes #&#8203;9136) (#&#8203;9206) (Ethan Rutherford)
* e171f6b Docs: add installing prerequisites. (#&#8203;9394) (薛定谔的猫)
* 74dfc87 Docs: update doc for class-methods-use-this (fixes #&#8203;8910) (#&#8203;9374) (Victor Hom)
* b4a9dbf Docs: show console call with no-restricted-syntax (fixes #&#8203;7806) (#&#8203;9376) (Victor Hom)
* 8da525f Fix: recognise multiline comments as multiline arrays (fixes #&#8203;9211) (#&#8203;9369) (Phil Quinn)
* c581b77 Chore: Error => TypeError (#&#8203;9390) (薛定谔的猫)
* ee99876 New: lines-between-class-members rule (fixes #&#8203;5949) (#&#8203;9141) (薛定谔的猫)
* 9d3f5ad Chore: report unused eslint-disable directives in ESLint codebase (#&#8203;9371) (Teddy Katz)
* 1167638 Update: add allowElseIf option to no-else-return (fixes #&#8203;9228) (#&#8203;9229) (Thomas Grainger)
* 4567ab1 New: Add the fix-dry-run flag (fixes #&#8203;9076) (#&#8203;9073) (Rafał Ruciński)

---

### [`v4.10.0`](https://github.com/eslint/eslint/releases/v4.10.0)

* bb6e60a Fix: Improve the doc for no-restricted-modules rule (fixes #&#8203;9437) (#&#8203;9495) (vibss2397)
* c529de9 Docs: Amend rule document to correct and complete it (refs #&#8203;6251). (#&#8203;9498) (Jonathan Pool)
* f9c6673 Chore: Add tests to cover array and object values and leading commas. (#&#8203;9502) (Jonathan Pool)
* 9169258 Chore: remove `npm run check-commit` script (#&#8203;9513) (Teddy Katz)
* 7d390b2 Docs: Revise contributor documentation on issue labels. (#&#8203;9469) (Jonathan Pool)
* d80b9d0 Fix: no-var don't fix globals (fixes #&#8203;9520) (#&#8203;9525) (Toru Nagashima)
* b8aa071 Fix: allow linting the empty string from stdin (fixes #&#8203;9515) (#&#8203;9517) (Teddy Katz)
* 350a72c Chore: regex.test => string.startsWith (#&#8203;9518) (薛定谔的猫)
* de0bef4 Chore: remove obsolete eslintbot templates (#&#8203;9512) (Teddy Katz)
* 720b6d5 Docs: Update ISSUE_TEMPLATE.md (#&#8203;9504) (薛定谔的猫)
* 2fa64b7 Fix: should not convert non-consecutive line comments to a single blo… (#&#8203;9475) (薛定谔的猫)
* 9725146 Fix: multiline-comment-style fix produces invalid code (fixes #&#8203;9461). (#&#8203;9463) (薛定谔的猫)
* b12cff8 Fix: Expected order of jsdoc tags (fixes #&#8203;9412) (#&#8203;9451) (Orlando Wenzinger)
* f054ab5 Docs: add `.md` to link (for github users) (#&#8203;9501) (薛定谔的猫)
* 5ed9cfc Docs: Correct violations of “Variable Declarations” in Code Conventions (#&#8203;9447) (Jonathan Pool)
* 3171097 Docs: Clears confusion on usage of global and local plugins.(#&#8203;9492) (Vasili Sviridov)
* 3204773 Chore: enable max-len. (#&#8203;9414) (薛定谔的猫)
* 0f71fef Docs: Unquote booleans in lines-between-class-members docs (#&#8203;9497) (Brandon Mills)
* b3d7532 Docs: use consistent terminology & fix link etc. (#&#8203;9490) (薛定谔的猫)
* 87db8ae Docs: Fix broken links (#&#8203;9488) (gpiress)
* 51bdb2f Docs: Incorrect link to related rule (#&#8203;9477) (Gavin King)
* 1a962e8 Docs: Add FAQ for when ESLint cannot find plugin (#&#8203;9467) (Kevin Partington)
* 8768b2d Fix: multiline-comment-style autofixer added trailing space (#&#8203;9454) (Teddy Katz)
* e830aa1 Fix: multiline-comment-style reports block comments followed by code (#&#8203;9450) (Teddy Katz)
* b12e5fe Docs: Repair broken links and add migration links. (#&#8203;9473) (Jonathan Pool)
* eca01ed Docs: Add missing info about special status of home-dir config files. (#&#8203;9472) (Jonathan Pool)
* eb8cfb1 Fix: change err report in constant condition (fixes #&#8203;9398) (#&#8203;9436) (Victor Hom)
* da77eb4 Chore: Revise no-config-file test to prevent false failure. (#&#8203;9443) (Jonathan Pool)
* 47e5f6f Docs: ensure "good commit message" examples actually follow guidelines (#&#8203;9466) (Teddy Katz)
* ebb530d Update: Don't ignore comments (no-trailing-spaces) (#&#8203;9416) (Chris van Marle)
* 5012661 Build: fix `npm run profile` script (fixes #&#8203;9397) (#&#8203;9455) (Teddy Katz)
* ecac0fd Docs: Remove blockBindings references (#&#8203;9446) (Jan Pilzer)
* 0b89865 Chore: ensure tests for internal rules get run (#&#8203;9453) (Teddy Katz)
* 052c504 Docs: suggest deleting branches after merging PRs (#&#8203;9449) (Teddy Katz)
* b31e55a Chore: move internal rules out of lib/ (#&#8203;9448) (Teddy Katz)
* a7521e3 Docs: improve examples for multiline-comment-style (#&#8203;9440) (Teddy Katz)

---

### [`v4.11.0`](https://github.com/eslint/eslint/releases/v4.11.0)

* d4557a6 Docs: disallow use of the comma operator using no-restricted-syntax (#&#8203;9585) (薛定谔的猫)
* d602f9e Upgrade: espree v3.5.2 (#&#8203;9611) (Kai Cataldo)
* 4def876 Chore: avoid handling rules instances in config-validator (#&#8203;9364) (Teddy Katz)
* fe5ac7e Chore: fix incorrect comment in safe-emitter.js (#&#8203;9605) (Teddy Katz)
* 6672fae Docs: Fixed a typo on lines-between-class-members doc (#&#8203;9603) (Moinul Hossain)
* 980ecd3 Chore: Update copyright and license info (#&#8203;9599) (薛定谔的猫)
* cc2c7c9 Build: use Node 8 in appveyor (#&#8203;9595) (薛定谔的猫)
* 2542f04 Docs: Add missing options for `lines-around-comment` (#&#8203;9589) (Clément Fiorio)
* b6a7490 Build: ensure fuzzer tests get run with `npm test` (#&#8203;9590) (Teddy Katz)
* 1073bc5 Build: remove shelljs-nodecli (refs #&#8203;9533) (#&#8203;9588) (Teddy Katz)
* 7e3bf6a Fix: edge-cases of semi-style (#&#8203;9560) (Toru Nagashima)
* e5a37ce Fix: object-curly-newline for flow code (#&#8203;9458) (Tiddo Langerak)
* 9064b9c Chore: add equalTokens in ast-utils. (#&#8203;9500) (薛定谔的猫)
* b7c5b19 Fix: Correct [object Object] output of error.data. (#&#8203;9561) (Jonathan Pool)
* 51c8cf0 Docs: Disambiguate definition of Update tag (#&#8203;9584) (Jonathan Pool)
* afc3c75 Docs: clarify what eslint-config-eslint is (#&#8203;9582) (Teddy Katz)
* aedae9d Docs: fix spelling in valid-typeof example (#&#8203;9574) (Maksim Degtyarev)
* 4c5aaf3 Docs: Fix typo in no-underscore-dangle rule (#&#8203;9567) (Fabien Lucas)
* 3623600 Chore: upgrade ajv@&#8203;5.3.0 (#&#8203;9557) (薛定谔的猫)
* 1b606cd Chore: Remove an indirect dependency on jsonify (#&#8203;9444) (Rouven Weßling)
* 4d7d7ab Update: Resolve npm installed formatters (#&#8203;5900) (#&#8203;9464) (Tom Erik Støwer)
* accc490 Fix: Files with no failures get "passing" testcase (#&#8203;9547) (Samuel Levy)
* ab0f66d Docs: Add examples to better show rule coverage. (#&#8203;9548) (Jonathan Pool)
* 88d2303 Chore: Add object-property-newline tests to increase coverage. (#&#8203;9553) (Jonathan Pool)
* 7f37b1c Build: test Node 9 on Travis (#&#8203;9556) (Teddy Katz)
* acccfbd Docs: Minor rephrase in `no-invalid-this`. (#&#8203;9542) (Francisc)
* 8f9c0fe Docs: improve id-match usage advice (#&#8203;9544) (Teddy Katz)
* a9606a3 Fix: invalid tests with super (fixes #&#8203;9539) (#&#8203;9545) (Teddy Katz)
* 8e1a095 Chore: enable a modified version of multiline-comment-style on codebase (#&#8203;9452) (Teddy Katz)
* cb60285 Chore: remove commented test for HTML formatter (#&#8203;9532) (Teddy Katz)
* 06b491e Docs: fix duplicate entries in changelog (#&#8203;9530) (Teddy Katz)
* 2224733 Chore: use eslint-plugin-rulesdir instead of --rulesdir for self-linting (#&#8203;9164) (Teddy Katz)
* 9cf4ebe Docs: add .md to link(for github users) (#&#8203;9529) (薛定谔的猫)

---

### [`v4.12.0`](https://github.com/eslint/eslint/releases/v4.12.0)

* 76dab18 Upgrade: doctrine@&#8203;^2.0.2 (#&#8203;9656) (Kevin Partington)
* 28c9c8e New: add a Linter#defineParser function (#&#8203;9321) (Ives van Hoorne)
* 5619910 Update: Add autofix for `sort-vars` (#&#8203;9496) (Trevin Hofmann)
* 71eedbf Update: add `beforeStatementContinuationChars` to semi (fixes #&#8203;9521) (#&#8203;9594) (Toru Nagashima)
* 4118f14 New: Adds implicit-arrow-linebreak rule (refs #&#8203;9510) (#&#8203;9629) (Sharmila Jesupaul)
* 208fb0f Fix: Use XML 1.1 on XML formatters (fixes #&#8203;9607) (#&#8203;9608) (Daniel Reigada)
* 6e04f14 Upgrade: `globals` to 11.0.1 (fixes #&#8203;9614) (#&#8203;9632) (Toru Nagashima)
* e13d439 Fix: space-in-parens crash (#&#8203;9655) (Toru Nagashima)
* 92171cc Docs: Updating migration guide for single-line disable (#&#8203;9385) (Justin Helmer)
* f39ffe7 Docs: remove extra punctuation from readme (#&#8203;9640) (Teddy Katz)
* a015234 Fix: prefer-destructuring false positive on "super" (fixes #&#8203;9625) (#&#8203;9626) (Kei Ito)
* 0cf081e Update: add importNames option to no-restricted-imports (#&#8203;9506) (Benjamin R Gibson)
* 332c214 Docs: Add @&#8203;platinumazure to TSC (#&#8203;9618) (Ilya Volodin)

---

### [`v4.12.1`](https://github.com/eslint/eslint/releases/v4.12.1)

* 1e362a0 Revert "Fix: Use XML 1.1 on XML formatters (fixes #&#8203;9607) (#&#8203;9608)" (#&#8203;9667) (Kevin Partington)

---

### [`v4.13.0`](https://github.com/eslint/eslint/releases/v4.13.0)

* 256481b Update: update handling of destructuring in camelcase (fixes #&#8203;8511) (#&#8203;9468) (Erin)
* d067ae1 Docs: Don’t use undocumented array-style configuration for max-len (#&#8203;9690) (Jed Fox)
* 1ad3091 Chore: fix test-suite to work with node master (#&#8203;9688) (Myles Borins)
* cdb1488 Docs: Adds an example with try/catch. (#&#8203;9672) (Jaap Taal)

---

### [`v4.13.1`](https://github.com/eslint/eslint/releases/v4.13.1)

* b72dc83 Fix: eol-last allow empty-string to always pass (refs #&#8203;9534) (#&#8203;9696) (Kevin Partington)
* d80aa7c Fix: camelcase destructure leading/trailing underscore (fixes #&#8203;9700) (#&#8203;9701) (Kevin Partington)
* d49d9d0 Docs: Add missing period to the README (#&#8203;9702) (Kevin Partington)
* 4564fe0 Chore: no-invalid-meta crash if no export assignment (refs #&#8203;9534) (#&#8203;9698) (Kevin Partington)

---

### [`v4.14.0`](https://github.com/eslint/eslint/releases/v4.14.0)

* be2f57e Update: support separate requires in one-var. (fixes #&#8203;6175) (#&#8203;9441) (薛定谔的猫)
* 370d614 Docs: Fix typos (#&#8203;9751) (Jed Fox)
* 8196c45 Chore: Reorganize CLI options and associated docs (#&#8203;9758) (Kevin Partington)
* 75c7419 Update: Logical-and is counted in `complexity` rule (fixes #&#8203;8535) (#&#8203;9754) (Kevin Partington)
* eb4b1e0 Docs: reintroduce misspelling in `valid-typeof` example (#&#8203;9753) (Teddy Katz)
* ae51eb2 New: Add allowImplicit option to array-callback-return (fixes #&#8203;8539) (#&#8203;9344) (James C. Davis)
* e9d5dfd Docs: improve no-extra-parens formatting (#&#8203;9747) (Rich Trott)
* 37d066c Chore: Add unit tests for overrides glob matching. (#&#8203;9744) (Robert Jackson)
* 805a94e Chore: Fix typo in CLIEngine test name (#&#8203;9741) (@&#8203;scriptdaemon)
* 1c2aafd Update: Improve parser integrations (fixes #&#8203;8392) (#&#8203;8755) (Toru Nagashima)
* 4ddc131 Upgrade: debug@&#8203;^3.1.0 (#&#8203;9731) (Kevin Partington)
* f252c19 Docs: Make the lint message `source` property a little more subtle (#&#8203;9735) (Jed Fox)
* 5a5c23c Docs: fix the link to contributing page (#&#8203;9727) (Victor Hom)
* f44ce11 Docs: change beginner to good first issue label text (#&#8203;9726) (Victor Hom)
* 14baa2e Chore: improve arrow-body-style error message (refs #&#8203;5498) (#&#8203;9718) (Teddy Katz)
* f819920 Docs: fix typos (#&#8203;9723) (Thomas Broadley)
* 43d4ba8 Fix: false positive on rule`lines-between-class-members` (fixes #&#8203;9665) (#&#8203;9680) (sakabar)

---

### [`v4.15.0`](https://github.com/eslint/eslint/releases/v4.15.0)

* 6ab04b5 New: Add context.report({ messageId }) (fixes #&#8203;6740) (#&#8203;9165) (Jed Fox)
* fc7f404 Docs: add url to each of the rules (refs #&#8203;6582) (#&#8203;9788) (Patrick McElhaney)
* fc44da9 Docs: fix sort-imports rule block language (#&#8203;9805) (ferhat elmas)
* 65f0176 New: CLIEngine#getRules() (refs #&#8203;6582) (#&#8203;9782) (Patrick McElhaney)
* c64195f Update: More detailed assert message for rule-tester (#&#8203;9769) (Weijia Wang)
* 9fcfabf Fix: no-extra-parens false positive (fixes: #&#8203;9755) (#&#8203;9795) (Erin)
* 61e5fa0 Docs: Add table of contents to Node.js API docs (#&#8203;9785) (Patrick McElhaney)
* 4c87f42 Fix: incorrect error messages of no-unused-vars (fixes #&#8203;9774) (#&#8203;9791) (akouryy)
* bbabf34 Update: add `ignoreComments` option to `indent` rule (fixes #&#8203;9018) (#&#8203;9752) (Kevin Partington)
* db431cb Docs: HTTP -> HTTPS (fixes #&#8203;9768) (#&#8203;9768) (Ronald Eddy Jr)
* cbf0fb9 Docs: describe how to feature-detect scopeManager/visitorKeys support (#&#8203;9764) (Teddy Katz)
* f7dcb70 Docs: Add note about "patch release pending" label to maintainer guide (#&#8203;9763) (Teddy Katz)

---

### [`v4.16.0`](https://github.com/eslint/eslint/releases/v4.16.0)

* e26a25f Update: allow continue instead of if wrap in guard-for-in (fixes #&#8203;7567) (#&#8203;9796) (Michael Ficarra)
* af043eb Update: Add NewExpression support to comma-style (#&#8203;9591) (Frazer McLean)
* 4f898c7 Build: Fix JSDoc syntax errors (#&#8203;9813) (Matija Marohnić)
* 13bcf3c Fix: Removing curly quotes in no-eq-null report message (#&#8203;9852) (Kevin Partington)
* b96fb31 Docs: configuration hierarchy for CLIEngine options (fixes #&#8203;9526) (#&#8203;9855) (PiIsFour)
* 8ccbdda Docs: Clarify that -c configs merge with `.eslintrc.*` (fixes #&#8203;9535) (#&#8203;9847) (Kevin Partington)
* 978574f Docs: Fix examples for no-useless-escape (#&#8203;9853) (Toru Kobayashi)
* cd5681d Chore: Deactivate consistent-docs-url in internal rules folder (#&#8203;9815) (Kevin Partington)
* 2e87ddd Docs: Sync messageId examples' style with other examples (#&#8203;9816) (Kevin Partington)
* 1d61930 Update: use doctrine range information in valid-jsdoc (#&#8203;9831) (Teddy Katz)
* 133336e Update: fix indent behavior on template literal arguments (fixes #&#8203;9061) (#&#8203;9820) (Teddy Katz)
* ea1b15d Fix: avoid crashing on malformed configuration comments (fixes #&#8203;9373) (#&#8203;9819) (Teddy Katz)
* add1e70 Update: fix indent bug on comments in ternary expressions (fixes #&#8203;9729) (#&#8203;9818) (Teddy Katz)
* 6a5cd32 Fix: prefer-destructuring error with computed properties (fixes #&#8203;9784) (#&#8203;9817) (Teddy Katz)
* 601f851 Docs: Minor modification to code comments for clarity (#&#8203;9821) (rgovind92)
* b9da067 Docs: fix misleading info about RuleTester column numbers (#&#8203;9830) (Teddy Katz)
* 2cf4522 Update: Rename and deprecate object-property-newline option (#&#8203;9570) (Jonathan Pool)
* acde640 Docs: Add ES 2018 to Configuring ESLint (#&#8203;9829) (Kai Cataldo)
* ccfce15 Docs: Minor tweaks to working with rules page (#&#8203;9824) (Kevin Partington)
* 54b329a Docs: fix substitution of {{ name }} (#&#8203;9822) (Andres Kalle)

---

### [`v4.17.0`](https://github.com/eslint/eslint/releases/v4.17.0)

* 1da1ada Update: Add "multiline" type to padding-line-between-statements (#&#8203;8668) (Matthew Bennett)
* bb213dc Chore: Use messageIds in some of the core rules (#&#8203;9648) (Jed Fox)
* 1aa1970 Docs: remove outdated rule naming convention (#&#8203;9925) (Teddy Katz)
* 3afaff6 Docs: Add prefer-destructuring variable reassignment example (#&#8203;9873) (LePirlouit)
* d20f6b4 Fix: Typo in error message when running npm (#&#8203;9866) (Maciej Kasprzyk)
* 51ec6a7 Docs: Use GitHub Multiple PR/Issue templates (#&#8203;9911) (Kai Cataldo)
* dc80487 Update: space-unary-ops uses astUtils.canTokensBeAdjacent (fixes #&#8203;9907) (#&#8203;9906) (Kevin Partington)
* 084351b Docs: Fix the messageId example (fixes #&#8203;9889) (#&#8203;9892) (Jed Fox)
* 9cbb487 Docs: Mention the `globals` key in the no-undef docs (#&#8203;9867) (Dan Dascalescu)

---

### [`v4.18.0`](https://github.com/eslint/eslint/releases/v4.18.0)

* 70f22f3 Chore: Apply memoization to config creation within glob utils (#&#8203;9944) (Kenton Jacobsen)
* 0e4ae22 Update: fix indent bug with binary operators/ignoredNodes (fixes #&#8203;9882) (#&#8203;9951) (Teddy Katz)
* 47ac478 Update: add named imports and exports for object-curly-newline (#&#8203;9876) (Nicholas Chua)
* e8efdd0 Fix: support Rest/Spread Properties (fixes #&#8203;9885) (#&#8203;9943) (Toru Nagashima)
* f012b8c Fix: support Async iteration (fixes #&#8203;9891) (#&#8203;9957) (Toru Nagashima)
* 74fa253 Docs: Clarify no-mixed-operators options (fixes #&#8203;9962) (#&#8203;9964) (Ivan Hayes)
* 426868f Docs: clean up key-spacing docs (fixes #&#8203;9900) (#&#8203;9963) (Abid Uzair)
* 4a6f22e Update: support eslint-disable-* block comments (fixes #&#8203;8781) (#&#8203;9745) (Erin)
* 777283b Docs: Propose fix typo for function (#&#8203;9965) (John Eismeier)
* bf3d494 Docs: Fix typo in max-len ignorePattern example. (#&#8203;9956) (Tim Martin)
* d64fbb4 Docs: fix typo in prefer-destructuring.md example (#&#8203;9930) (Vse Mozhet Byt)
* f8d343f Chore: Fix default issue template (#&#8203;9946) (Kai Cataldo)

---

### [`v4.18.1`](https://github.com/eslint/eslint/releases/v4.18.1)

* f417506 Fix: ensure no-await-in-loop reports the correct node (fixes #&#8203;9992) (#&#8203;9993) (Teddy Katz)
* 3e99363 Docs: Fixed typo in key-spacing rule doc (#&#8203;9987) (Jaid)
* 7c2cd70 Docs: deprecate experimentalObjectRestSpread (#&#8203;9986) (Toru Nagashima)

---

### [`v4.18.2`](https://github.com/eslint/eslint/releases/v4.18.2)

* 6b71fd0 Fix: table@&#8203;4.0.2, because 4.0.3 needs "ajv": "^6.0.1" (#&#8203;10022) (Mathieu Seiler)
* 3c697de Chore: fix incorrect comment about linter.verify return value (#&#8203;10030) (Teddy Katz)
* 9df8653 Chore: refactor parser-loading out of linter.verify (#&#8203;10028) (Teddy Katz)
* f6901d0 Fix: remove catastrophic backtracking vulnerability (fixes #&#8203;10002) (#&#8203;10019) (Jamie Davis)
* e4f52ce Chore: Simplify dataflow in linter.verify (#&#8203;10020) (Teddy Katz)
* 33177cd Chore: make library files non-executable (#&#8203;10021) (Teddy Katz)
* 558ccba Chore: refactor directive comment processing (#&#8203;10007) (Teddy Katz)
* 18e15d9 Chore: avoid useless catch clauses that just rethrow errors (#&#8203;10010) (Teddy Katz)
* a1c3759 Chore: refactor populating configs with defaults in linter (#&#8203;10006) (Teddy Katz)
* aea07dc Fix: Make max-len ignoreStrings ignore JSXText (fixes #&#8203;9954) (#&#8203;9985) (Rachael Sim)

---

### [`v4.19.0`](https://github.com/eslint/eslint/releases/v4.19.0)

* 55a1593 Update: consecutive option for one-var (fixes #&#8203;4680) (#&#8203;9994) (薛定谔的猫)
* 8d3814e Fix: false positive about ES2018 RegExp enhancements (fixes #&#8203;9893) (#&#8203;10062) (Toru Nagashima)
* 935f4e4 Docs: Clarify default ignoring of node_modules (#&#8203;10092) (Matijs Brinkhuis)
* 72ed3db Docs: Wrap `Buffer()` in backticks in `no-buffer-constructor` rule description (#&#8203;10084) (Stephen Edgar)
* 3aded2f Docs: Fix lodash typos, make spacing consistent (#&#8203;10073) (Josh Smith)
* e33bb64 Chore: enable no-param-reassign on ESLint codebase (#&#8203;10065) (Teddy Katz)
* 66a1e9a Docs: fix possible typo (#&#8203;10060) (Vse Mozhet Byt)
* 2e68be6 Update: give a node at least the indentation of its parent (fixes #&#8203;9995) (#&#8203;10054) (Teddy Katz)
* 72ca5b3 Update: Correctly indent JSXText with trailing linebreaks (fixes #&#8203;9878) (#&#8203;10055) (Teddy Katz)
* 2a4c838 Docs: Update ECMAScript versions in FAQ (#&#8203;10047) (alberto)

---

### [`v4.19.1`](https://github.com/eslint/eslint/releases/v4.19.1)

* 3ff5d11 Fix: no-invalid-regexp not understand variable for flags (fixes #&#8203;10112) (#&#8203;10113) (薛定谔的猫)
* abc765c Fix: object-curly-newline minProperties w/default export (fixes #&#8203;10101) (#&#8203;10103) (Kevin Partington)
* 6f9e155 Docs: Update ambiguous for...in example for guard-for-in (#&#8203;10114) (CJ R)
* 0360cc2 Chore: Adding debug logs on successful plugin loads (#&#8203;10100) (Kevin Partington)
* a717c5d Chore: Adding log at beginning of unit tests in Makefile.js (#&#8203;10102) (Kevin Partington)

---

</details>


<details>
<summary>Commits</summary>

#### v4.15.0
-   [`6ab04b5`](https://github.com/eslint/eslint/commit/6ab04b553ec3ecb65ed3473b3f873b5a72af3675) New: Add context.report({ messageId }) (fixes #&#8203;6740) (#&#8203;9165)
-   [`2dfc3bd`](https://github.com/eslint/eslint/commit/2dfc3bdabacc59c9cdf24fb07961efda52d5dd02) Build: changelog update for 4.15.0
-   [`e14ceb0`](https://github.com/eslint/eslint/commit/e14ceb0451b0a18b4a78feb7d3521caf1c9d5747) 4.15.0
#### v4.16.0
-   [`54b329a`](https://github.com/eslint/eslint/commit/54b329ab0cb197baf8223515cbc17ca84ea88063) Docs: fix substitution of {{ name }} (#&#8203;9822)
-   [`ccfce15`](https://github.com/eslint/eslint/commit/ccfce15784fd2bedf8f19e89f009697f42eb4e0d) Docs: Minor tweaks to working with rules page (#&#8203;9824)
-   [`acde640`](https://github.com/eslint/eslint/commit/acde640da093bf7181de59b40eec41da2456ee3e) Docs: Add ES 2018 to Configuring ESLint (#&#8203;9829)
-   [`2cf4522`](https://github.com/eslint/eslint/commit/2cf452243351d2f9ff704aaf13a517cbde494ad4) Update: Rename and deprecate object-property-newline option (#&#8203;9570)
-   [`b9da067`](https://github.com/eslint/eslint/commit/b9da067deb7c15f6a908614001f755d39db43aa1) Docs: fix misleading info about RuleTester column numbers (#&#8203;9830)
-   [`601f851`](https://github.com/eslint/eslint/commit/601f8518ab2ba3fb6bcc00062b1fdca5f369c042) Docs: Minor modification to code comments for clarity (#&#8203;9821)
-   [`6a5cd32`](https://github.com/eslint/eslint/commit/6a5cd32e5a75b23558ad0282e080ffbb6affcad0) Fix: prefer-destructuring error with computed properties (fixes #&#8203;9784) (#&#8203;9817)
-   [`add1e70`](https://github.com/eslint/eslint/commit/add1e703a52b86662386f9b9b177b0fc86a33acc) Update: fix indent bug on comments in ternary expressions (fixes #&#8203;9729) (#&#8203;9818)
-   [`ea1b15d`](https://github.com/eslint/eslint/commit/ea1b15d3f996f10b63fcaec2efb44efdb7cda3a0) Fix: avoid crashing on malformed configuration comments (fixes #&#8203;9373) (#&#8203;9819)
-   [`133336e`](https://github.com/eslint/eslint/commit/133336e04edc59c7441fc0670b0b24dd15ded9b3) Update: fix indent behavior on template literal arguments (fixes #&#8203;9061) (#&#8203;9820)
-   [`1d61930`](https://github.com/eslint/eslint/commit/1d6193047b59a5e6b5cc296961b3cb79fbf07074) Update: use doctrine range information in valid-jsdoc (#&#8203;9831)
-   [`2e87ddd`](https://github.com/eslint/eslint/commit/2e87ddd43be4460b48d6c88fb51d3d138de47138) Docs: Sync messageId examples&#x27; style with other examples (#&#8203;9816)
-   [`cd5681d`](https://github.com/eslint/eslint/commit/cd5681dfb6e398f5fd869dfbe654cfa8ea32d34a) Chore: Deactivate consistent-docs-url in internal rules folder (#&#8203;9815)
-   [`978574f`](https://github.com/eslint/eslint/commit/978574f8b0d0e66d5f781e08bb874e0a9000278c) Docs: Fix examples for no-useless-escape (#&#8203;9853)
-   [`8ccbdda`](https://github.com/eslint/eslint/commit/8ccbdda6a4cf3ff9b2601f3278eebbb8a922c97e) Docs: Clarify that -c configs merge with `.eslintrc.*` (fixes #&#8203;9535) (#&#8203;9847)
-   [`b96fb31`](https://github.com/eslint/eslint/commit/b96fb318f8dd63937df74458b67f7bfb46ddeb66) Docs: configuration hierarchy for CLIEngine options (fixes #&#8203;9526) (#&#8203;9855)
-   [`13bcf3c`](https://github.com/eslint/eslint/commit/13bcf3ca531d699ee68567154e720377219773d0) Fix: Removing curly quotes in no-eq-null report message (#&#8203;9852)
-   [`4f898c7`](https://github.com/eslint/eslint/commit/4f898c74b4bdfea52c7cd9b8d2bf12c3c349eb88) Build: Fix JSDoc syntax errors (#&#8203;9813)
-   [`af043eb`](https://github.com/eslint/eslint/commit/af043eb6551d74d79710c6fbc0919bab203b9867) Update: Add NewExpression support to comma-style (#&#8203;9591)
-   [`e26a25f`](https://github.com/eslint/eslint/commit/e26a25fdeb191f48a44e3684ec5dd062a36306e7) Update: allow continue instead of if wrap in guard-for-in (fixes #&#8203;7567) (#&#8203;9796)
-   [`1a9ddee`](https://github.com/eslint/eslint/commit/1a9ddeed94b5e6f9d4dd45339faa540147b1b44c) Build: changelog update for 4.16.0
-   [`33ca1ea`](https://github.com/eslint/eslint/commit/33ca1ea67e41a05ff1283f6be36553db3904ec1f) 4.16.0
#### v4.17.0
-   [`9cbb487`](https://github.com/eslint/eslint/commit/9cbb487e8e84ff3268c05ab47b3b72c51b5f766e) Docs: Mention the `globals` key in the no-undef docs (#&#8203;9867)
-   [`084351b`](https://github.com/eslint/eslint/commit/084351bedb1001fc460e9acea4952b0b6139ec23) Docs: Fix the messageId example (fixes #&#8203;9889) (#&#8203;9892)
-   [`dc80487`](https://github.com/eslint/eslint/commit/dc804875fcac38dc4c89b7631007d534815c6078) Update: space-unary-ops uses astUtils.canTokensBeAdjacent (fixes #&#8203;9907) (#&#8203;9906)
-   [`51ec6a7`](https://github.com/eslint/eslint/commit/51ec6a71f2df0229577a568c4a5251eb8f02bf5a) Docs: Use GitHub Multiple PR/Issue templates (#&#8203;9911)
-   [`d20f6b4`](https://github.com/eslint/eslint/commit/d20f6b429839b253706e3e34f9b7a4a6c05f3fc2) Fix: Typo in error message when running npm (#&#8203;9866)
-   [`3afaff6`](https://github.com/eslint/eslint/commit/3afaff6039f4c5b3a8421b2746fb7bfa5d13ae9b) Docs: Add prefer-destructuring variable reassignment example (#&#8203;9873)
-   [`1aa1970`](https://github.com/eslint/eslint/commit/1aa1970632953dae3f3044386aaf043aea7ebf04) Docs: remove outdated rule naming convention (#&#8203;9925)
-   [`bb213dc`](https://github.com/eslint/eslint/commit/bb213dccfd0661fb82e8de42cbaa996c97722929) Chore: Use messageIds in some of the core rules (#&#8203;9648)
-   [`1da1ada`](https://github.com/eslint/eslint/commit/1da1ada2ce21960a450e7e97762cfca0c7dd7233) Update: Add &quot;multiline&quot; type to padding-line-between-statements (#&#8203;8668)
-   [`5ad3fb2`](https://github.com/eslint/eslint/commit/5ad3fb228a514823aa94b27ddd8943c0cac71690) Build: changelog update for 4.17.0
-   [`2af9446`](https://github.com/eslint/eslint/commit/2af94466fe8f87058fad4bd168958d2a7612a79d) 4.17.0
#### v4.18.0
-   [`f8d343f`](https://github.com/eslint/eslint/commit/f8d343fa29623051f97df0e5ea0139bd4258dfdb) Chore: Fix default issue template (#&#8203;9946)
-   [`d64fbb4`](https://github.com/eslint/eslint/commit/d64fbb41d344f70f155ee334c5eddac4c9d0861c) Docs: fix typo in prefer-destructuring.md example (#&#8203;9930)
-   [`bf3d494`](https://github.com/eslint/eslint/commit/bf3d4943aa583f042c315e640ef90018d016f2c2) Docs: Fix typo in max-len ignorePattern example. (#&#8203;9956)
-   [`777283b`](https://github.com/eslint/eslint/commit/777283b340ebaf4ca0a7ace6601d7d3b327cc8d4) Docs: Propose fix typo for function (#&#8203;9965)
-   [`4a6f22e`](https://github.com/eslint/eslint/commit/4a6f22e94d4ba1f1e5df748ab08c9f7d0b0140ec) Update: support eslint-disable-* block comments (fixes #&#8203;8781) (#&#8203;9745)
-   [`426868f`](https://github.com/eslint/eslint/commit/426868fdc70daa2996e35416190dc3835360da85) Docs: clean up key-spacing docs (fixes #&#8203;9900) (#&#8203;9963)
-   [`74fa253`](https://github.com/eslint/eslint/commit/74fa253555b60ea018e65655dd3866ed134c707c) Docs: Clarify no-mixed-operators options (fixes #&#8203;9962) (#&#8203;9964)
-   [`f012b8c`](https://github.com/eslint/eslint/commit/f012b8c7802e702a69ea8b3522cdc4c7842f038c) Fix: support Async iteration (fixes #&#8203;9891) (#&#8203;9957)
-   [`e8efdd0`](https://github.com/eslint/eslint/commit/e8efdd063f6dfaf32c9b4e237aff272721c01c1a) Fix: support Rest/Spread Properties (fixes #&#8203;9885) (#&#8203;9943)
-   [`47ac478`](https://github.com/eslint/eslint/commit/47ac478f3272fca771461e1cc6d4e91b1ecaaccc) Update: add named imports and exports for object-curly-newline (#&#8203;9876)
-   [`0e4ae22`](https://github.com/eslint/eslint/commit/0e4ae22d4adebd1cb603ac9cb55daf70c9b921d0) Update: fix indent bug with binary operators/ignoredNodes (fixes #&#8203;9882) (#&#8203;9951)
-   [`70f22f3`](https://github.com/eslint/eslint/commit/70f22f3f545402811068cee1fae5035be3dc4600) Chore: Apply memoization to config creation within glob utils (#&#8203;9944)
-   [`89d55ca`](https://github.com/eslint/eslint/commit/89d55ca21d2d6b36b629dc78bef3c3dcbadf0296) Build: changelog update for 4.18.0
-   [`883a2a2`](https://github.com/eslint/eslint/commit/883a2a2eee1adcc832d43ef77140ff7e2736e676) 4.18.0
#### v4.18.1
-   [`7c2cd70`](https://github.com/eslint/eslint/commit/7c2cd70c95f6795169d72577754452716b440851) Docs: deprecate experimentalObjectRestSpread (#&#8203;9986)
-   [`3e99363`](https://github.com/eslint/eslint/commit/3e9936371df8235c1dfe5f7d58fad4632e45e975) Docs: Fixed typo in key-spacing rule doc (#&#8203;9987)
-   [`f417506`](https://github.com/eslint/eslint/commit/f417506198d2ab8deca1e6127c164cef882d356f) Fix: ensure no-await-in-loop reports the correct node (fixes #&#8203;9992) (#&#8203;9993)
-   [`537b5c3`](https://github.com/eslint/eslint/commit/537b5c32f8ad49063375a4961f9eb54c68de8963) Build: changelog update for 4.18.1
-   [`8c237d8`](https://github.com/eslint/eslint/commit/8c237d8be368798acea876adedd3533a99e30368) 4.18.1
#### v4.18.2
-   [`aea07dc`](https://github.com/eslint/eslint/commit/aea07dc88689ff0d6fea27e4099ce7f1a42ff90a) Fix: Make max-len ignoreStrings ignore JSXText (fixes #&#8203;9954) (#&#8203;9985)
-   [`a1c3759`](https://github.com/eslint/eslint/commit/a1c3759adfd087c8b5c3c892b92885b7dded4224) Chore: refactor populating configs with defaults in linter (#&#8203;10006)
-   [`18e15d9`](https://github.com/eslint/eslint/commit/18e15d978c17503f7ca352333a47069afcb70a1c) Chore: avoid useless catch clauses that just rethrow errors (#&#8203;10010)
-   [`558ccba`](https://github.com/eslint/eslint/commit/558ccba0fc8cafd969c7f18ff09be7fc0670536f) Chore: refactor directive comment processing (#&#8203;10007)
-   [`33177cd`](https://github.com/eslint/eslint/commit/33177cd863e37897fd1c7e98f2f69ba31028453b) Chore: make library files non-executable (#&#8203;10021)
-   [`e4f52ce`](https://github.com/eslint/eslint/commit/e4f52ce6a6b6149e21b1d1a2f3f5f71d58d7106a) Chore: Simplify dataflow in linter.verify (#&#8203;10020)
-   [`f6901d0`](https://github.com/eslint/eslint/commit/f6901d0bcf6c918ac4e5c6c7c4bddeb2cb715c09) Fix: remove catastrophic backtracking vulnerability (fixes #&#8203;10002) (#&#8203;10019)
-   [`9df8653`](https://github.com/eslint/eslint/commit/9df865326616b9865ab186c9769e95bc0bf98a20) Chore: refactor parser-loading out of linter.verify (#&#8203;10028)
-   [`3c697de`](https://github.com/eslint/eslint/commit/3c697de6182b19d49b910a33b1bc6b0a0e2569b3) Chore: fix incorrect comment about linter.verify return value (#&#8203;10030)
-   [`6b71fd0`](https://github.com/eslint/eslint/commit/6b71fd0bcbf9cc00ed4076587f5692b72f6e9aa5) Fix: table@&#8203;4.0.2, because 4.0.3 needs &quot;ajv&quot;: &quot;^6.0.1&quot; (#&#8203;10022)
-   [`817b84b`](https://github.com/eslint/eslint/commit/817b84bf523dee12884ed37c9c86328e9fb5c532) Build: changelog update for 4.18.2
-   [`22ff6f3`](https://github.com/eslint/eslint/commit/22ff6f3ab122f61c10fa51f9b1082f2e6f302938) 4.18.2
#### v4.19.0
-   [`2a4c838`](https://github.com/eslint/eslint/commit/2a4c838c7d9d13050028b23925f4691d215d8337) Docs: Update ECMAScript versions in FAQ (#&#8203;10047)
-   [`72ca5b3`](https://github.com/eslint/eslint/commit/72ca5b35b843cc376a66632e07c307f923063701) Update: Correctly indent JSXText with trailing linebreaks (fixes #&#8203;9878) (#&#8203;10055)
-   [`2e68be6`](https://github.com/eslint/eslint/commit/2e68be643178eeb86f2b9f66bc1670b624cb09f2) Update: give a node at least the indentation of its parent (fixes #&#8203;9995) (#&#8203;10054)
-   [`66a1e9a`](https://github.com/eslint/eslint/commit/66a1e9aa85c37c1d4430ad633d8354930c818796) Docs: fix possible typo (#&#8203;10060)
-   [`e33bb64`](https://github.com/eslint/eslint/commit/e33bb64601b1dffe1b8bc8b2a5142121c8b56523) Chore: enable no-param-reassign on ESLint codebase (#&#8203;10065)
-   [`3aded2f`](https://github.com/eslint/eslint/commit/3aded2f984a6bc972a3f2198fddcf4a323d7a201) Docs: Fix lodash typos, make spacing consistent (#&#8203;10073)
-   [`72ed3db`](https://github.com/eslint/eslint/commit/72ed3dbcdda8ec1387e75676c3166fec71337a69) Docs: Wrap `Buffer()` in backticks in `no-buffer-constructor` rule description (#&#8203;10084)
-   [`935f4e4`](https://github.com/eslint/eslint/commit/935f4e460d83c39f107118c4c4dbb7f6b58684b1) Docs: Clarify default ignoring of node_modules (#&#8203;10092)
-   [`8d3814e`](https://github.com/eslint/eslint/commit/8d3814e4ae823e58f40539047bb35bcaf5c76660) Fix: false positive about ES2018 RegExp enhancements (fixes #&#8203;9893) (#&#8203;10062)
-   [`55a1593`](https://github.com/eslint/eslint/commit/55a15936346def8ddc0c5023431df20bec798fb2) Update: consecutive option for one-var (fixes #&#8203;4680) (#&#8203;9994)
-   [`16fc59e`](https://github.com/eslint/eslint/commit/16fc59e95140aeb7d7cda732aca7921a12b046c1) Build: changelog update for 4.19.0
-   [`4f595e8`](https://github.com/eslint/eslint/commit/4f595e8a7cc1fefae866d2cf0e758515d6098e3c) 4.19.0
#### v4.19.1
-   [`a717c5d`](https://github.com/eslint/eslint/commit/a717c5db7575c0ba677f1fd1e909cba08818bfae) Chore: Adding log at beginning of unit tests in Makefile.js (#&#8203;10102)
-   [`0360cc2`](https://github.com/eslint/eslint/commit/0360cc25c86619d30e37e25d4ce9a78309591c18) Chore: Adding debug logs on successful plugin loads (#&#8203;10100)
-   [`6f9e155`](https://github.com/eslint/eslint/commit/6f9e15514e7a6b880b7c735ac9e8b43aed3cc67e) Docs: Update ambiguous for...in example for guard-for-in (#&#8203;10114)
-   [`abc765c`](https://github.com/eslint/eslint/commit/abc765c1bc6b546db82cb5cd038b66a3aa68b315) Fix: object-curly-newline minProperties w/default export (fixes #&#8203;10101) (#&#8203;10103)
-   [`3ff5d11`](https://github.com/eslint/eslint/commit/3ff5d11fe2ed601d4e0226bde50c06fe7c7f16ac) Fix: no-invalid-regexp not understand variable for flags (fixes #&#8203;10112) (#&#8203;10113)
-   [`b446650`](https://github.com/eslint/eslint/commit/b446650083012a152ec55dd19c20f2ce951eb30a) Build: changelog update for 4.19.1
-   [`f1f1bdf`](https://github.com/eslint/eslint/commit/f1f1bdfffe0c2675e42cb6ad58145d40a6870135) 4.19.1

</details>