### PR TITLE
chore(deps): update dependency standard to ^11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "babel-eslint": "^6.1.2",
     "eslint": "^2.1.0",
     "eslint-plugin-filenames": "^1.1.0",
-    "standard": "^7.1.2"
+    "standard": "^11.0.0"
   }
 }


### PR DESCRIPTION
This Pull Request updates dependency [standard](https://github.com/standard/standard) from `^7.1.2` to `^11.0.0`



<details>
<summary>Release Notes</summary>

### [`v8.0.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;800---2016-08-23)

This release contains a bunch of goodies, including new rules that catch potential
programmer errors (i.e. bugs) and enforce additional code consistency.

However, the best feature is surely the new `--fix` command line flag to
automatically fix problems. If you ever used
[`standard-format`](https://www.npmjs.com/package/standard-format)
and ran into issues with the lack of ES2015+ support, you'll be happy about
`--fix`.

`standard --fix` is built into `standard` v8.0.0 for maximum convenience, it
supports ES2015, and it's lightweight (no additional dependencies since it's part
of ESLint which powers `standard`). Lots of problems are already fixable, and more
are getting added with each ESLint release.

`standard` also outputs a message ("Run `standard --fix` to automatically fix
some problems.") when it detects problems that can be fixed automatically so you
can save time!

With `standard` v8.0.0, we are also dropping support for Node.js versions prior to
v4. Node.js 0.10 and 0.12 are in maintenance mode and will be unsupported at the
end of 2016. Node.js 4 is the current LTS version. If you are using an older
version of Node.js, we recommend upgrading to at least Node.js 4 as soon as
possible. If you are unable to upgrade to Node.js 4 or higher, then we recommend
continuing to use `standard` v7.x until you are ready to upgrade Node.js.

**Important:** We will not be updating the `standard` v7.x versions going forward.
All bug fixes and enhancements will land in `standard` v8.x.

Full changelog below. Cheers!
##### New features

- Upgrade to ESLint v3 (http://eslint.org/docs/user-guide/migrating-to-3.0.0) [#&#8203;565](`https://github.com/standard/standard/pull/565`)
  - **BREAKING:** Drop support for node < 4 (this was a decision made by the ESLint team)
- Expose ESLint's `--fix` command line flag [#&#8203;540](`https://github.com/standard/standard/issues/540`) [standard-engine/#&#8203;107](`https://github.com/Flet/standard-engine/issues/107`)
  - Lightweight, no additional dependencies, fixes dozens of rules automatically
##### New rules

*(Estimated % of affected standard users, based on test suite in parens)*

- Enforce placing object properties on separate lines ([object-property-newline](http://eslint.org/docs/rules/object-property-newline)) [#&#8203;524](`https://github.com/standard/standard/issues/524`) (2%)
- Require block comments to be balanced ([spaced-comment "balanced"](http://eslint.org/docs/rules/spaced-comment)) [#&#8203;572](`https://github.com/standard/standard/issues/572`) (2%)
- Disallow constant expressions in conditions ([no-constant-condition](http://eslint.org/docs/rules/no-constant-condition)) [#&#8203;563](`https://github.com/standard/standard/issues/563`) (1%)
- Disallow renaming import, export, and destructured assignments to the same name ([no-useless-rename](http://eslint.org/docs/rules/no-useless-rename)) [#&#8203;537](`https://github.com/standard/standard/issues/537`) (0%)
- Disallow spacing between rest and spread operators and their expressions ([rest-spread-spacing](http://eslint.org/docs/rules/rest-spread-spacing)) [#&#8203;567](`https://github.com/standard/standard/issues/567`) (0%)
- Disallow the Unicode Byte Order Mark (BOM) ([unicode-bom](http://eslint.org/docs/rules/unicode-bom)) [#&#8203;538](`https://github.com/standard/standard/issues/538`) (0%)
- Disallow assignment to native objects/global variables ([no-global-assign](http://eslint.org/docs/rules/no-global-assign)) [#&#8203;596](`https://github.com/standard/standard/issues/596`) (0%)
- Disallow negating the left operand of relational operators ([no-unsafe-negation](http://eslint.org/docs/rules/no-unsafe-negation)) [#&#8203;595](`https://github.com/standard/standard/issues/595`) (0%)
- Disallow template literal placeholder syntax in regular strings ([no-template-curly-in-string](http://eslint.org/docs/rules/no-template-curly-in-string)) [#&#8203;594](`https://github.com/standard/standard/issues/594`) (0%)
- Disallow tabs in file ([no-tabs](http://eslint.org/docs/rules/no-tabs)) [#&#8203;593](`https://github.com/standard/standard/issues/593`) (0%)
##### Changed rules

- Relax rule: Allow template literal strings (backtick strings) to avoid escaping  [#&#8203;421](`https://github.com/standard/standard/issues/421`)
- Relax rule: Do not enforce spacing around * in generator functions (`https://github.com/standard/standard/issues/564`#issuecomment-234699126)
  - This is a temporary workaround for `babel` users who use async generator functions.

---

### [`v8.1.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;810---2016-09-17)

- Update ESLint from 3.3.x to 3.5.x
- Around 10 additional rules are now fixable with `standard --fix`

---

### [`v8.2.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;820---2016-09-26)

For many users, this release should eliminate the need to specify `babel-eslint` as
a custom parser, since `standard` can now parse ES7 (i.e. ES2016) syntax out of the
box.

- Support ES7 (i.e. ES2016) syntax.
- Update ESLint from 3.5.x to 3.6.x
- 4 additional rules are now fixable with `standard --fix`

---

### [`v8.3.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;830---2016-09-29)

The last release (`8.2.0`) added ES7 support. This release (`8.3.0`) adds ES8
support ...just 3 days later!

This release should eliminate the need to specify `babel-eslint` as a custom
parser, since `standard` can now parse ES8 (i.e. ES2017) syntax out of the box.
That means `async` and `await` will just work.

- Support ES8 (i.e. ES2017) syntax.

---

### [`v8.4.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;840---2016-10-10)

- Update ESLint from 3.6.x to 3.7.x
- 5 additional rules are now fixable with `standard --fix`
- Use more conservative semver ranges [#&#8203;654](`https://github.com/standard/standard/issues/654`)

---

### [`v8.5.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;850---2016-10-25)

- Update ESLint from 3.7.x to 3.8.x
- 2 additional rules are now fixable with `standard --fix`

---

### [`v8.6.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;860---2016-11-22)

- Update ESLint from 3.8.x to 3.10.x
- 3 additional rules are now fixable with `standard --fix`

---

### [`v9.0.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;900---2017-02-28)

It's time for a new major version of `standard`! As usual, this release contains a
bunch of awesomeness to help you keep your code in tip-top shape!

We've added several new rules designed to **catch potential programmer errors**
(i.e. bugs), as well as rules to make programmer intent **more explicit** in
certain circumstances.

This release continues our trend of tightening up rules so that, wherever possible,
there's one "right" way to do things. This design goal is intended to reduce the
time that teams and maintainers spend giving code review feedback in pull requests.

When you upgrade, consider running `standard --fix` to automatically fix some of the
errors caught by the new rules in this version.

*Note: If you use the Chai test framework, you will need to make some changes to
your tests to improve their robustness. [Read about the changes you need to make](`https://github.com/standard/standard/issues/690`#issuecomment-278533482).*
##### New features

- Update ESLint from 3.10.x to 3.15.x
- 3 additional rules are now fixable with `standard --fix`
##### New rules

*(Estimated % of affected standard users, based on test suite in parens)*

- Disallow mixing different operators without parens ([no-mixed-operators](http://eslint.org/docs/rules/no-mixed-operators)) [#&#8203;566](`https://github.com/standard/standard/issues/566`) (5%)
- Enforce 1 newline at end of file (previously 1 or 2 were ok) ([no-multiple-empty-lines](http://eslint.org/docs/rules/no-multiple-empty-lines)) [#&#8203;733](`https://github.com/standard/standard/issues/733`) (3%)
- Disallow Unused Expressions ([no-unused-expressions](http://eslint.org/docs/rules/no-unused-expressions)) [#&#8203;690](`https://github.com/standard/standard/issues/690`) (3%)
  - Note: this affects users of the Chai test framework. [Read about the changes you need to make](`https://github.com/standard/standard/issues/690`#issuecomment-278533482).
- Disallow redundant return statements ([no-useless-return](http://eslint.org/docs/rules/no-useless-return)) [#&#8203;694](`https://github.com/standard/standard/issues/694`) (1%)
- Disallow Incorrect Early Use ([no-use-before-define](http://eslint.org/docs/rules/no-use-before-define)) [#&#8203;636](`https://github.com/standard/standard/issues/636`) (0%)
- Enforce that Promise rejections are passed an Error object as a reason ([prefer-promise-reject-errors](http://eslint.org/docs/rules/prefer-promise-reject-errors)) [#&#8203;777](`https://github.com/standard/standard/issues/777`) (0%)
- Enforce comparing `typeof` expressions against string literals ([valid-typeof](http://eslint.org/docs/rules/valid-typeof)) [#&#8203;629](`https://github.com/standard/standard/issues/629`) (0%)
- Enforce spacing around * in generator functions ([generator-star-spacing](http://eslint.org/docs/rules/generator-star-spacing)) [#&#8203;724](`https://github.com/standard/standard/issues/724`) (0%)
- Disallow Unnecessary Labels ([no-extra-label](http://eslint.org/docs/rules/no-extra-label)) [#&#8203;736](`https://github.com/standard/standard/issues/736`) (0%)
- Disallow spacing between template tags and their literals ([template-tag-spacing](http://eslint.org/docs/rules/template-tag-spacing)) [#&#8203;755](`https://github.com/standard/standard/issues/775`) (0%)
- Disallow padding within switch statements and classes ([padded-blocks](http://eslint.org/docs/rules/padded-blocks)) [#&#8203;610](`https://github.com/standard/standard/issues/610`) (0%)
- Enforce that Symbols are passed a description ([symbol-description](http://eslint.org/docs/rules/symbol-description)) [#&#8203;630](`https://github.com/standard/standard/issues/630`) (0%)
##### Changed rules

- Relax rule: allow TypeScript Triple-Slash Directives ([spaced-comment](http://eslint.org/docs/rules/spaced-comment)) [#&#8203;660](`https://github.com/standard/standard/issues/660`)
- Relax rule: allow Flow Comments ([spaced-comment](http://eslint.org/docs/rules/spaced-comment)) [#&#8203;661](`https://github.com/standard/standard/issues/661`)

---

### [`v9.0.1`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;901---2017-03-07)

##### Changed rules

- Relax rule: Allow mixing basic operators without parens ([no-mixed-operators](http://eslint.org/docs/rules/no-mixed-operators)) [#&#8203;816](`https://github.com/standard/standard/issues/816`)
  - Specifically, these operators: `+`, `-`, `*`, `/`, `%`, and `**`

---

### [`v9.0.2`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;902---2017-03-17)

##### Changed rules

- Relax rule: Allow tagged template string expressions ([no-unused-expressions](http://eslint.org/docs/rules/no-unused-expressions)) [#&#8203;822](`https://github.com/standard/standard/issues/822`)

---

### [`v10.0.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;1000---2017-04-04)

**`standard` just turned 10.0.0!** 🎉

As with every new major release, there are lots of new rules in 10.0.0 designed to
help catch bugs and make programmer intent more explicit.

`standard` is more popular than ever – **330,000 downloads per month!** It's even
more popular – **670,000 downloads per month** – if you include the
[shareable ESLint config](https://www.npmjs.com/package/eslint-config-standard)
that we also publish.

The most important change in 10.0.0 is that **using deprecated Node.js APIs is now
considered an error**. It's finally time to update those dusty old APIs!

Deprecated APIs are problematic because they may print warning messages in the
console in recent versions of Node.js. This often confuses users and leads to
unnecessary support tickets for project maintainers.

Some deprecated APIs are even insecure (or at least prone to incorrect usage) which
can have serious security implications. For that reason, `standard` now considers
usage of `Buffer(num)` to be an error, since this function returns uninitialized
program memory which could contain confidential information like passwords or keys.

Instead of `Buffer(num)`, consider using `Buffer.alloc(num)` or `Buffer.from(obj)`
which make the programmer's intent clearer. These functions exist in all currently
supported versions of Node.js, including Node.js 4.x. For more background,
[see this Node.js issue](`https://github.com/nodejs/node/issues/4660`).

We also improved some rules to support common patterns in code bases that use
React, JSX, and Flow.

When you upgrade, consider running `standard --fix` to automatically fix some of
the issues caught by this new version.
##### New features

- Update ESLint from 3.15.x to 3.19.x.
- Node.js API: Add `standard.lintTextSync` method
##### New rules

*(Estimated % of affected standard users, based on test suite in parens)*

- Disallow using deprecated Node.js APIs ([node/no-deprecated-api](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-deprecated-api.md)) [#&#8203;693](`https://github.com/standard/standard/issues/693`) (13%)
  - Ensures that code always runs without warnings on the latest versions of Node.js
  - Ensures that safe Buffer methods (`Buffer.from()`, `Buffer.alloc()`) are used instead of `Buffer()`
- Enforce callbacks always called with Node.js-style error first ([standard/no-callback-literal](https://github.com/xjamundx/eslint-plugin-standard#rules-explanations)) [#&#8203;623](`https://github.com/standard/standard/issues/623`) (3%)
  - Functions named `callback` or `cb` must be invoked with `null`, `undefined`, or an `Error` as the first argument
  - Disallows using a string instead of an `Error` object
  - Disallows confusing callbacks that do not follow the standard Node.js pattern
- Disallow any imports that come after non-import statements ([import/first](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md)) [#&#8203;806](`https://github.com/standard/standard/issues/806`) (1%)
- Disallow unnecessary return await ([no-return-await](http://eslint.org/docs/rules/no-return-await)) [#&#8203;695](`https://github.com/standard/standard/issues/695`) (0%)
- Disallow comma-dangle in functions ([comma-dangle](http://eslint.org/docs/rules/comma-dangle)) [#&#8203;787](`https://github.com/standard/standard/issues/787`) (0%)
- Disallow repeated exports of names or defaults ([import/export](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md)) [#&#8203;806](`https://github.com/standard/standard/issues/806`) (0%)
- Disallow import of modules using absolute paths ([import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)) [#&#8203;806](`https://github.com/standard/standard/issues/806`) (0%)
- Disallow Webpack loader syntax in imports ([import/no-webpack-loader-syntax](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md)) [#&#8203;806](`https://github.com/standard/standard/issues/806`) (0%)
- Disallow comparing against -0 ([no-compare-neg-zero](http://eslint.org/docs/rules/no-compare-neg-zero)) [#&#8203;812](`https://github.com/standard/standard/issues/812`) (0%)
##### Changed rules

- Relax rule: allow using `...rest` to omit properties from an object ([no-unused-vars](http://eslint.org/docs/rules/no-unused-vars)) [#&#8203;800](`https://github.com/standard/standard/issues/800`)
  - This is a common and useful pattern in React/JSX apps!
- Relax rule: allow Flow `import type` statements ([import/no-duplicates](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md)) [#&#8203;599](`https://github.com/standard/standard/issues/599`)
  - These are no longer considered to be "duplicate imports"
- Relax rule: Treat `process.exit()` the same as `throw` in code path analysis ([node/process-exit-as-throw](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/process-exit-as-throw.md)) [#&#8203;699](`https://github.com/standard/standard/issues/699`)
  - Makes certain other rules work better and give fewer false positives
- Relax rule: allow Unnecessary Labels ([no-extra-label](http://eslint.org/docs/rules/no-extra-label))
  - Redundant, since "no-labels" is already enabled, which is more restrictive

---

### [`v10.0.1`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;1001---2017-04-06)

- Internal changes (incremented dependency versions)

---

### [`v10.0.2`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;1002---2017-04-14)

##### Changed rules

- Relax rule: Disallow import of modules using absolute paths ([import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)) [#&#8203;861](`https://github.com/standard/standard/issues/861`)
  - This rule was responsible for up to 25% of the running time of `standard`, so we are disabling it until its performance improves.

---

### [`v10.0.3`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;1003---2017-08-06)

- Internal changes (incremented dependency versions)

---

### [`v11.0.0`](https://github.com/standard/standard/blob/master/CHANGELOG.md#&#8203;1100---2018-02-18)

This release has no new rules, but it does update to the latest version of `eslint`,
version 4, which has some significant changes to existing rules. Most updates make
the indentation rules more strict.

Thankfully, most users will just need to run `standard --fix` to update code to be
compliant.
##### New features

- Update `eslint` from ~3.19.0 to ~4.18.0.
  - The `indent` rule is more strict.
  - The `padded-blocks` rule is more strict.
  - The `space-before-function-paren` rule is more strict.
  - The `no-multi-spaces` rule is more strict.
  - Minor improvements to:
   - `no-extra-parens`,
   - `no-unexpected-multiline`,
   - `no-regex-spaces`, and
   - `space-unary-ops`

- Update `eslint-plugin-import` from `~2.2.0` to `~2.8.0`
  - Updated for eslint 4.0 compatibility.
  - Various small bug fixes included related to `import/*` rules.

- Update `eslint-plugin-node` from `~4.2.2` to `~6.0.0`
  - The `no-deprecated-api` rule is updated with Node.js 8 support and improved
    Node 6 support.

- Upodate `eslint-plugin-promise` from `~3.5.0` to `~3.6.0`.

- Update `eslint-plugin-react` from `~6.10.0` to `~7.6.1`
  - Fix `jsx-indent` crash
  - Fix `jsx-indent` indentation calculation with nested JSX.
  - Fix `jsx-no-undef` will not check the global scope by default.
  - Fix `jsx-curly-spacing` newline with object literals bug.
  - Fix `jsx-curly-spacing` schema incompatibility with ESLint 4.2.0.
  - Fix alignment bug in `jsx-indent`.
##### Changed rules

- Relax rule: Don't mark Rails Asset Pipeline comments (comments that start with `//=`)
  as errors. ([spaced-comment](http://eslint.org/docs/rules/spaced-comment)) [#&#8203;918](`https://github.com/standard/standard/issues/918`)

👏 Huge thanks to [@&#8203;Flet] for putting together most of this
release!

---

</details>


<details>
<summary>Commits</summary>

#### v10.0.3
-   [`54e5b95`](https://github.com/standard/standard/commit/54e5b9500e6dc8619fcf86f453b1ba040bc38c3f) Update README.md with corrent repo
-   [`1d35e6d`](https://github.com/standard/standard/commit/1d35e6de1e83cfe98dd19df50d7fd4deca5ef5c3) Fix typo
-   [`6dd2c05`](https://github.com/standard/standard/commit/6dd2c056e96b40d8a69df110062f5b2473d74eba) Merge pull request #&#8203;939 from anteriovieira/patch-1
-   [`94b4044`](https://github.com/standard/standard/commit/94b404422db4903e467f433f1a7d141ae1444063) rentograph is using standard
-   [`878ea7b`](https://github.com/standard/standard/commit/878ea7b58f73c0052ddc99383cb3b261fc2fafd2) Merge pull request #&#8203;945 from rentograph/add-rentograph-logo
-   [`034fac7`](https://github.com/standard/standard/commit/034fac7ef67f7baba16a1f691e87a0c79dadcb97) Merge pull request #&#8203;936 from CafeLungo/patch-1
-   [`37932eb`](https://github.com/standard/standard/commit/37932eb9fc7daaa2753f00592632c81a2e4e65dc) compress logos
-   [`e7c5e83`](https://github.com/standard/standard/commit/e7c5e836613a3ec4ea264fd60f3ab55923221f82) feross/standard -&gt; standard/standard
-   [`65a845a`](https://github.com/standard/standard/commit/65a845ac6ab0e1913f514f9bc189b1e98cf20fe1) Merge pull request #&#8203;934 from ematipico/feature/ItalianTranslation
-   [`abb6c97`](https://github.com/standard/standard/commit/abb6c975d31cdf413fcbebbaea2d0ca5e11a288e) Merge pull request #&#8203;952 from standard/repo-url
-   [`6bba965`](https://github.com/standard/standard/commit/6bba965b216f6898460885ed77b9cea65383e0d7) add consistent translation links to every page
-   [`3895bc6`](https://github.com/standard/standard/commit/3895bc6f6a05e1ac03b51c5dce802a31f4a253f5) move english readme/rules to docs/ folder
-   [`6d59566`](https://github.com/standard/standard/commit/6d59566cfc898dc895be779ac468ccd6412e5bef) Merge pull request #&#8203;953 from standard/translations
-   [`34490f7`](https://github.com/standard/standard/commit/34490f7240242d44a26a4ebe07a9abf210670499) Merge branch &#x27;translation-kr&#x27; of https://github.com/devjin0617/standard into devjin0617-translation-kr
-   [`e79a692`](https://github.com/standard/standard/commit/e79a6920ad65152e003451ebd4b10263617e799e) Merge branch &#x27;devjin0617-translation-kr&#x27;
-   [`2fa8b0f`](https://github.com/standard/standard/commit/2fa8b0f4f93898f56be0e052948028c4aca5da17) change more feross/standard -&gt; standard/standard
-   [`8cc2285`](https://github.com/standard/standard/commit/8cc2285fa954e9e74b2bffbae53786c3ba69cb2d) Add a security policy
-   [`9770303`](https://github.com/standard/standard/commit/97703038334a80694c3bd5198014879bc9dbcb38) Merge pull request #&#8203;954 from standard/security
-   [`f00b169`](https://github.com/standard/standard/commit/f00b169c74a1f8e3052433b9f7b53d05ca142826) more feross/standard -&gt; standard/standard
-   [`873bc9b`](https://github.com/standard/standard/commit/873bc9b117c8f9fbb615f6b2db3a741d019546de) Adding valid example for no-unsafe-negation
-   [`ac9e09e`](https://github.com/standard/standard/commit/ac9e09e007c12254bb1f163c38ba85dd3f929dd4) Merge pull request #&#8203;961 from igorsantos07/patch-1
-   [`4a6e0d0`](https://github.com/standard/standard/commit/4a6e0d0bd4e8548dbda1bbf8ab0d9d201dbc5e5d) Update dependecy of eslint-config-standard-jsx
-   [`cfb84fe`](https://github.com/standard/standard/commit/cfb84fedbff8f80ace02d9ab692db6b7c815105f) Remove tilde to lock down eslint-config-standard-jsx version
-   [`d22676e`](https://github.com/standard/standard/commit/d22676e6cee35965d9b9231cd9e6c93588cacd09) Merge pull request #&#8203;963 from daper/patch-1
-   [`82a0d5c`](https://github.com/standard/standard/commit/82a0d5c1361fe1c294b58626a3c644e682dc5e29) changelog
-   [`91e80a1`](https://github.com/standard/standard/commit/91e80a1feba31bb1c7b1ab57283c4e3cd93d56ab) 10.0.3
#### v11.0.0
-   [`9bc26cc`](https://github.com/standard/standard/commit/9bc26cc4d2cac3e4470071bc4904c8d3a7ce9a1b) Update email in AUTHORS.md
-   [`98c4153`](https://github.com/standard/standard/commit/98c4153b0bfb81705c8bd3ab28cb59c2d331e7da) Merge pull request #&#8203;1034 from pablopunk/patch-1
-   [`ce894b1`](https://github.com/standard/standard/commit/ce894b11f02e23be4f90b3feae2f5181ea97d90e) Fix typo and some reference links
-   [`8077142`](https://github.com/standard/standard/commit/8077142d1f87961354962447cb24fdeac66fcfe9) Merge pull request #&#8203;1043 from idlua/fix/portuguese-readme
-   [`ef927d3`](https://github.com/standard/standard/commit/ef927d308df4637b996b31fc5cd4e87667b1595c) RULES.md -&gt; RULES-en.md in README-en.md
-   [`6930d53`](https://github.com/standard/standard/commit/6930d5351aaf50a0f796674602c2592faf94aa1a) Merge pull request #&#8203;1051 from tonyfinn/patch-1
-   [`22f15d5`](https://github.com/standard/standard/commit/22f15d5e8efe2d4b92d7e0667874af06a58af93d) chore(package): update dependencies
-   [`f945a2f`](https://github.com/standard/standard/commit/f945a2f1a35c35db6d089cb7a308154000440389) docs(readme): add Greenkeeper badge
-   [`e1c58fb`](https://github.com/standard/standard/commit/e1c58fb1aa48daad349970b3b3daf09ccade2a7c) Fix typo
-   [`4acfb74`](https://github.com/standard/standard/commit/4acfb744eec7192632076e6569d81eae6a9bbbd9) Merge pull request #&#8203;1057 from sonicdoe/patch-1
-   [`c1770a9`](https://github.com/standard/standard/commit/c1770a93718c5c6646cca54482b37a42c8e48b78) readme tweaks
-   [`ff379a0`](https://github.com/standard/standard/commit/ff379a0c5e02c29fe6b48342e1f4113078fbe5d1) add stdlib sponsor logo
-   [`aef406a`](https://github.com/standard/standard/commit/aef406affe2726d6bb973f9b2e9ced704384dc88) copy
-   [`5edd7c3`](https://github.com/standard/standard/commit/5edd7c3548bc7a38259487c2070a8888664b1584) chore: adapt code to updated dependencies
-   [`c2bd85c`](https://github.com/standard/standard/commit/c2bd85c35103c84e913687501c10bad68e0aee00) Merge pull request #&#8203;1054 from standard/greenkeeper/initial
-   [`78be324`](https://github.com/standard/standard/commit/78be32440ff00790cb7721fb3a28b9fd4b36f652) eslint@&#8203;4.18
-   [`4ff2152`](https://github.com/standard/standard/commit/4ff2152aa43563752d522dee5b82d68f94943474) eslint-plugin-node@&#8203;6
-   [`47489da`](https://github.com/standard/standard/commit/47489dad065b9e5df04fc8b4d0a77f6fea97777f) update changelog
-   [`8376af6`](https://github.com/standard/standard/commit/8376af6b9bb2bf45afc380bbb9cce11d5a237e7a) don&#x27;t peg CPU when running tests
-   [`98f513c`](https://github.com/standard/standard/commit/98f513c65c685551cb85113dafeed541f1a75d7e) test style
-   [`a5333eb`](https://github.com/standard/standard/commit/a5333eb74c28f83a98ad741886512e298cf0726c) changelog
-   [`c9e8503`](https://github.com/standard/standard/commit/c9e8503a3e7e9a0117ae6aa3bae8fa7154ff3192) changelog
-   [`7ff022f`](https://github.com/standard/standard/commit/7ff022fe1e5e4c81bbc6e5ac2e0849a48ab0cc63) eslint-config-standard@&#8203;11.0.0
-   [`0147989`](https://github.com/standard/standard/commit/01479896b434eb22ea9b5b4b87b2036ccfbccdd8) eslint-config-standard-jsx@&#8203;5.0.0
-   [`538f087`](https://github.com/standard/standard/commit/538f087761b34cca4d9a8d5f9c4d71cf41968a07) standard-engine@&#8203;8.0
-   [`7b5e482`](https://github.com/standard/standard/commit/7b5e48249747fe3dc54dfa224d118b31dd9c55a9) .npmignore
-   [`cc79290`](https://github.com/standard/standard/commit/cc7929058a9f22a89de85e68dcb410f70cad501e) .npmignore
-   [`50c466c`](https://github.com/standard/standard/commit/50c466cb2a287cbac365629fbd634baf2a8b27e5) remove hardcoded npm run test scripts
-   [`22673fc`](https://github.com/standard/standard/commit/22673fc7ac2dad0239e8a16660734ac4b1c50056) test: add --fix flag to attempt fixing packages before failing
-   [`76bf851`](https://github.com/standard/standard/commit/76bf851c5e24a2a956a19c04a1d635021418506f) standard-packages@&#8203;3.4.0
-   [`4b7fac5`](https://github.com/standard/standard/commit/4b7fac5e97b09b3d102fb07db8c6ccf0fbe6c1a3) 11.0.0
-   [`a599426`](https://github.com/standard/standard/commit/a5994268773a1c12d9e1e23c786ed8f7e90d41e5) authors
#### v11.0.1
-   [`7c390c9`](https://github.com/standard/standard/commit/7c390c907472049f20056c3d0fc3c30987bfc2ba) Fixing my personal email to the correct one
-   [`3ec7e04`](https://github.com/standard/standard/commit/3ec7e04d2feec2cbb9fe56e0c2ea47a0cc5cc312) Merge pull request #&#8203;1070 from standard/ematipico-patch-1
-   [`9b687ad`](https://github.com/standard/standard/commit/9b687add2ea654b43df57195a1303801dd37d1b6) authors
-   [`7bdc9f2`](https://github.com/standard/standard/commit/7bdc9f252a5bb3115bf1d15972d75b68a074620b) fix(package): update eslint-plugin-react to version 7.7.0
-   [`cb30712`](https://github.com/standard/standard/commit/cb3071213d2223bdbe447a1a17aca9694bf0ff75) fix(package): update eslint-plugin-import to version 2.9.0
-   [`4f8c1f5`](https://github.com/standard/standard/commit/4f8c1f5632bac8317327c2822961e7580d71321d) Fix webstorm.md links
-   [`c93ac0d`](https://github.com/standard/standard/commit/c93ac0d56402496f80570288692004443b997804) Merge pull request #&#8203;1076 from tumobi/fix-links
-   [`738edc4`](https://github.com/standard/standard/commit/738edc4021109897c6141a7f7176d3ad9303402d) readme: add standard talk
-   [`116a871`](https://github.com/standard/standard/commit/116a87190bd6c1a1e1b0e51b4f273fa859bb9731) fix(package): update eslint-plugin-promise to version 3.7.0
-   [`ebf6620`](https://github.com/standard/standard/commit/ebf662083e55beacdc8638e77a8ad189aa7dc85b) Merge pull request #&#8203;1087 from standard/greenkeeper/eslint-plugin-promise-3.7.0
-   [`a5293dd`](https://github.com/standard/standard/commit/a5293dd7cb9209d4fd9749647e70d4da5fe9dfcc) Merge pull request #&#8203;1075 from standard/greenkeeper/eslint-plugin-import-2.9.0
-   [`9dc888f`](https://github.com/standard/standard/commit/9dc888fe0b1b6400c5617b74daaf49637dd8e07f) Merge branch &#x27;master&#x27; into greenkeeper/eslint-plugin-react-7.7.0
-   [`e818224`](https://github.com/standard/standard/commit/e818224c4a3832bcd01b6edafa881adb731c1dbf) Merge pull request #&#8203;1072 from standard/greenkeeper/eslint-plugin-react-7.7.0
-   [`a5b779f`](https://github.com/standard/standard/commit/a5b779f479a63ccebb114ebc2edff64c31730611) Swap README.md and RULES.md symlinks (#&#8203;1090)
-   [`504fcff`](https://github.com/standard/standard/commit/504fcffa42401cfe0b9926bb33029b6325128975) docs(README): update typeform logo
-   [`c40c799`](https://github.com/standard/standard/commit/c40c799e96f67e2c80bd840ca0dde5a65f399490) Merge pull request #&#8203;1091 from mackermans/master
-   [`5382643`](https://github.com/standard/standard/commit/538264304d7a93b97998d2b2d0d666b054a1312a) Replace Opbeat with Elastic logo
-   [`34a3c40`](https://github.com/standard/standard/commit/34a3c40ba20797d44f7894fdf5277f0116dfdfa7) Merge pull request #&#8203;1092 from watson/elastic-logo
-   [`b7e6cbc`](https://github.com/standard/standard/commit/b7e6cbc4c04fc1df1de2d9ccb31fdc5ff176b924) 11.0.1
-   [`670a3be`](https://github.com/standard/standard/commit/670a3be9e96cc1808b47ecabcddb742bff49f898) authors

</details>